### PR TITLE
Let `get_output_status` use a `u64` for the index.

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -51,7 +51,7 @@ pub struct MerkleProof {
 pub struct OutputStatus {
     spent: bool,
     txid: Option<Txid>,
-    vin: Option<Vin>,
+    vin: Option<u64>,
     status: Option<TxStatus>,
 }
 

--- a/src/async.rs
+++ b/src/async.rs
@@ -23,7 +23,7 @@ use log::{debug, error, info, trace};
 
 use reqwest::{Client, StatusCode};
 
-use crate::{Builder, Error, MerkleProof, OutputStatus, Tx, TxStatus, Vout};
+use crate::{Builder, Error, MerkleProof, OutputStatus, Tx, TxStatus};
 
 #[derive(Debug)]
 pub struct AsyncClient {
@@ -134,15 +134,15 @@ impl AsyncClient {
         Ok(Some(resp.error_for_status()?.json().await?))
     }
 
-    /// Get the spending status of an output given a [`Txid`] and [`Vout`].
+    /// Get the spending status of an output given a [`Txid`] and the output index.
     pub async fn get_output_status(
         &self,
         txid: &Txid,
-        vout: &Vout,
+        index: u64,
     ) -> Result<Option<OutputStatus>, Error> {
         let resp = self
             .client
-            .get(&format!("{}/tx/{}/outspend/{}", self.url, txid, vout.value))
+            .get(&format!("{}/tx/{}/outspend/{}", self.url, txid, index))
             .send()
             .await?;
 

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -26,7 +26,7 @@ use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::{BlockHeader, Script, Transaction, Txid};
 
-use crate::{Builder, Error, MerkleProof, OutputStatus, Tx, TxStatus, Vout};
+use crate::{Builder, Error, MerkleProof, OutputStatus, Tx, TxStatus};
 
 #[derive(Debug, Clone)]
 pub struct BlockingClient {
@@ -149,15 +149,15 @@ impl BlockingClient {
         }
     }
 
-    /// Get the spending status of an output given a [`Txid`] and [`Vout`].
+    /// Get the spending status of an output given a [`Txid`] and the output index.
     pub fn get_output_status(
         &self,
         txid: &Txid,
-        vout: &Vout,
+        index: u64,
     ) -> Result<Option<OutputStatus>, Error> {
         let resp = self
             .agent
-            .get(&format!("{}/tx/{}/outspend/{}", self.url, txid, vout.value))
+            .get(&format!("{}/tx/{}/outspend/{}", self.url, txid, index))
             .call();
 
         match resp {


### PR DESCRIPTION
Unfortunately #4 had a minor bug as the `get_output_status` API method doesn't require a full `struct Vout` as input and doesn't return the data to populate a full `struct Vin`.

This PR fixes this by just using `u64` for the respective index fields.

Now tested to work with both the `blocking` and `async` variant.