### PR TITLE
Add `get_txid_at_block_index` API method

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -79,6 +79,30 @@ impl AsyncClient {
         }
     }
 
+    /// Get a [`Txid`] of a transaction given its index in a block with a given hash.
+    pub async fn get_txid_at_block_index(
+        &self,
+        block_hash: &BlockHash,
+        index: usize,
+    ) -> Result<Option<Txid>, Error> {
+        let resp = self
+            .client
+            .get(&format!(
+                "{}/block/{}/txid/{}",
+                self.url,
+                block_hash.to_string(),
+                index
+            ))
+            .send()
+            .await?;
+
+        if let StatusCode::NOT_FOUND = resp.status() {
+            return Ok(None);
+        }
+
+        Ok(Some(deserialize(&Vec::from_hex(&resp.text().await?)?)?))
+    }
+
     /// Get the status of a [`Transaction`] given its [`Txid`].
     pub async fn get_tx_status(&self, txid: &Txid) -> Result<Option<TxStatus>, Error> {
         let resp = self

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -84,6 +84,34 @@ impl BlockingClient {
         }
     }
 
+    /// Get a [`Txid`] of a transaction given its index in a block with a given hash.
+    pub fn get_txid_at_block_index(
+        &self,
+        block_hash: &BlockHash,
+        index: usize,
+    ) -> Result<Option<Txid>, Error> {
+        let resp = self
+            .agent
+            .get(&format!(
+                "{}/block/{}/txid/{}",
+                self.url,
+                block_hash.to_string(),
+                index
+            ))
+            .call();
+
+        match resp {
+            Ok(resp) => Ok(Some(deserialize(&Vec::from_hex(&resp.into_string()?)?)?)),
+            Err(ureq::Error::Status(code, _)) => {
+                if is_status_not_found(code) {
+                    return Ok(None);
+                }
+                Err(Error::HttpResponse(code))
+            }
+            Err(e) => Err(Error::Ureq(e)),
+        }
+    }
+
     /// Get the status of a [`Transaction`] given its [`Txid`].
     pub fn get_tx_status(&self, txid: &Txid) -> Result<Option<TxStatus>, Error> {
         let resp = self


### PR DESCRIPTION
This PR adds the capability to retrieve a `Txid` by block hash and index, i.e., [this API call](https://github.com/blockstream/esplora/blob/master/API.md#get-blockhashtxidindex)