### PR TITLE
Add feature (parity) tests for API methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ reqwest = { version = "0.11", optional = true, default-features = false, feature
 
 [dev-dependencies]
 serde_json = "1.0"
+tokio = { version = "1.20.1", features = ["full"] }
+electrsd = { version = "0.19.1", features = ["legacy", "esplora_a33e97e1", "bitcoind_22_0"] }
+electrum-client = "0.10"
+lazy_static = "1.4.0"
 
 [features]
 default = ["blocking", "async", "async-https"]

--- a/src/async.rs
+++ b/src/async.rs
@@ -87,12 +87,7 @@ impl AsyncClient {
     ) -> Result<Option<Txid>, Error> {
         let resp = self
             .client
-            .get(&format!(
-                "{}/block/{}/txid/{}",
-                self.url,
-                block_hash.to_string(),
-                index
-            ))
+            .get(&format!("{}/block/{}/txid/{}", self.url, block_hash, index))
             .send()
             .await?;
 

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -92,12 +92,7 @@ impl BlockingClient {
     ) -> Result<Option<Txid>, Error> {
         let resp = self
             .agent
-            .get(&format!(
-                "{}/block/{}/txid/{}",
-                self.url,
-                block_hash.to_string(),
-                index
-            ))
+            .get(&format!("{}/block/{}/txid/{}", self.url, block_hash, index))
             .call();
 
         match resp {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,19 +205,28 @@ mod test {
     };
     use electrum_client::ElectrumApi;
     use lazy_static::lazy_static;
+    use std::env;
     use std::sync::{Mutex, Once};
     use std::time::Duration;
 
     lazy_static! {
         static ref BITCOIND: BitcoinD = {
-            let bitcoind_exe =
-                bitcoind::downloaded_exe_path().expect("bitcoind version feature must be enabled");
+            let bitcoind_exe = env::var("BITCOIND_EXE")
+                .ok()
+                .or(bitcoind::downloaded_exe_path().ok())
+                .expect(
+                    "you should provide env var BITCOIND_EXE or specifiy a bitcoind version feature",
+                );
             let conf = bitcoind::Conf::default();
             BitcoinD::with_conf(bitcoind_exe, &conf).unwrap()
         };
         static ref ELECTRSD: ElectrsD = {
-            let electrs_exe =
-                electrsd::downloaded_exe_path().expect("electrs version feature must be enabled");
+            let electrs_exe = env::var("ELECTRS_EXE")
+                .ok()
+                .or(electrsd::downloaded_exe_path())
+                .expect(
+                    "you should provide env var ELECTRS_EXE or specifiy a electrsd version feature",
+                );
             let mut conf = electrsd::Conf::default();
             conf.http_enabled = true;
             ElectrsD::with_conf(electrs_exe, &BITCOIND, &conf).unwrap()


### PR DESCRIPTION
This PR adds basic feature (parity) tests for the API methods:

- [x] `get_tx` 
- [x] `get_tx_no_opt`
- [x] `get_tx_at_block_index`
- [x] `get_tx_status`
- [x] `get_header`
- [x] `get_merkle_proof`
- [x] `get_output_status`
- [x] `get_height`
- [x] `get_tip_hash`
- [x] `get_fee_estimates`
- [x] `scripthash_txs`