### PR TITLE
Allow to retrieve a block header by hash

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -113,6 +113,10 @@ impl AsyncClient {
         Ok(Some(resp.error_for_status()?.json().await?))
     }
 
+    #[deprecated(
+        since = "0.1.2",
+        note = "Deprecated to improve alignment with Esplora API. Users should use `get_block_hash` and `get_header_by_hash` methods directly."
+    )]
     /// Get a [`BlockHeader`] given a particular block height.
     pub async fn get_header(&self, block_height: u32) -> Result<BlockHeader, Error> {
         let block_hash = self.get_block_hash(block_height).await?;

--- a/src/async.rs
+++ b/src/async.rs
@@ -116,7 +116,11 @@ impl AsyncClient {
     /// Get a [`BlockHeader`] given a particular block height.
     pub async fn get_header(&self, block_height: u32) -> Result<BlockHeader, Error> {
         let block_hash = self.get_block_hash(block_height).await?;
+        self.get_header_by_hash(&block_hash).await
+    }
 
+    /// Get a [`BlockHeader`] given a particular block hash.
+    pub async fn get_header_by_hash(&self, block_hash: &BlockHash) -> Result<BlockHeader, Error> {
         let resp = self
             .client
             .get(&format!("{}/block/{}/header", self.url, block_hash))

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -129,7 +129,11 @@ impl BlockingClient {
     /// Get a [`BlockHeader`] given a particular block height.
     pub fn get_header(&self, block_height: u32) -> Result<BlockHeader, Error> {
         let block_hash = self.get_block_hash(block_height)?;
+        self.get_header_by_hash(&block_hash)
+    }
 
+    /// Get a [`BlockHeader`] given a particular block hash.
+    pub fn get_header_by_hash(&self, block_hash: &BlockHash) -> Result<BlockHeader, Error> {
         let resp = self
             .agent
             .get(&format!("{}/block/{}/header", self.url, block_hash))

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -127,6 +127,10 @@ impl BlockingClient {
     }
 
     /// Get a [`BlockHeader`] given a particular block height.
+    #[deprecated(
+        since = "0.1.2",
+        note = "Deprecated to improve alignment with Esplora API. Users should use `get_block_hash` and `get_header_by_hash` methods directly."
+    )]
     pub fn get_header(&self, block_height: u32) -> Result<BlockHeader, Error> {
         let block_hash = self.get_block_hash(block_height)?;
         self.get_header_by_hash(&block_hash)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,10 +450,13 @@ mod test {
 
     #[cfg(all(feature = "blocking", any(feature = "async", feature = "async-https")))]
     #[tokio::test]
-    async fn test_get_header() {
+    async fn test_get_header_by_hash() {
         let (blocking_client, async_client) = setup_clients().await;
-        let block_header = blocking_client.get_header(53).unwrap();
-        let block_header_async = async_client.get_header(53).await.unwrap();
+
+        let block_hash = BITCOIND.client.get_block_hash(23).unwrap();
+
+        let block_header = blocking_client.get_header_by_hash(&block_hash).unwrap();
+        let block_header_async = async_client.get_header_by_hash(&block_hash).await.unwrap();
         assert_eq!(block_header, block_header_async);
     }
 


### PR DESCRIPTION
~~Based on #13 since it probably land soon.~~

This PR adds a method allowing to retrieve a `BlockHeader` via a given `BlockHash` and reuses it in `get_height`.