### PR TITLE
Fix deprecation version of `get_header`

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -114,7 +114,7 @@ impl AsyncClient {
     }
 
     #[deprecated(
-        since = "0.1.2",
+        since = "0.2.0",
         note = "Deprecated to improve alignment with Esplora API. Users should use `get_block_hash` and `get_header_by_hash` methods directly."
     )]
     /// Get a [`BlockHeader`] given a particular block height.

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -128,7 +128,7 @@ impl BlockingClient {
 
     /// Get a [`BlockHeader`] given a particular block height.
     #[deprecated(
-        since = "0.1.2",
+        since = "0.2.0",
         note = "Deprecated to improve alignment with Esplora API. Users should use `get_block_hash` and `get_header_by_hash` methods directly."
     )]
     pub fn get_header(&self, block_height: u32) -> Result<BlockHeader, Error> {


### PR DESCRIPTION
In #17, we deprecated `get_header` and assumed the next version would be 0.1.2, but it turned out to be 0.2.