### PR TITLE
Upgrade `ureq` to 2.5.0 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ path = "src/lib.rs"
 serde = { version = "1.0", features = ["derive"] }
 bitcoin = { version = "0.29.1", features = ["serde"] }
 log = "^0.4"
-ureq = { version = "~2.2.0", features = ["json"], optional = true }
+ureq = { version = "2.5.0", features = ["json"], optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }
 
 [dev-dependencies]
 serde_json = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
-electrsd = { version = "0.21.1", features = ["legacy", "esplora_a33e97e1", "bitcoind_22_0"] }
+electrsd = { version = "0.22.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_22_0"] }
 electrum-client = "0.12.0"
 lazy_static = "1.4.0"
 


### PR DESCRIPTION
This PR upgrades `ureq` to `2.5.0` so that we are compatible with `bitcoind` 0.28. Also moved `electrsd` to 0.22.0 which has version 0.28 of `bitcoind`. This PR fixes #23