### PR TITLE
Change ureq into caret version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 serde = { version = "1.0", features = ["derive"] }
 bitcoin = { version = "0.29.1", features = ["serde"] }
 log = "^0.4"
-ureq = { version = "~2.2.0", features = ["json"], optional = true }
+ureq = { version = "2.2.0", features = ["json"], optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Relax `ureq` version requirement. Current `ureq` is at `v2.5.0` so we should be able to use that if other crates have the requirement. 

Motivated by failure observed in building `bdk-cli` with latest `electrsd` 

```
$ cargo build
    Updating crates.io index
error: failed to select a version for `ureq`.
    ... required by package `bitcoind v0.28.0`
    ... which satisfies dependency `bitcoind = "^0.28.0"` of package `electrsd v0.22.0`
    ... which satisfies dependency `electrsd = "^0.22"` of package `bdk-cli v0.6.0 (/home/raj/github-repo/bdk-cli)`
versions that meet the requirements `^2.5.0` are: 2.5.0

all possible versions conflict with previously selected packages.

  previously selected package `ureq v2.2.0`
    ... which satisfies dependency `ureq = "~2.2.0"` of package `esplora-client v0.1.1`
    ... which satisfies dependency `esplora-client = "^0.1.1"` of package `bdk v0.23.0`
    ... which satisfies dependency `bdk = "^0.23"` of package `bdk-cli v0.6.0 (/home/raj/github-repo/bdk-cli)`
```