### PR TITLE
Add `get_recent_blocks` api

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -79,6 +79,12 @@ pub struct BlockTime {
     pub height: u32,
 }
 
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct Block {
+    pub id: BlockHash,
+    pub height: u32,
+}
+
 impl Tx {
     pub fn to_tx(&self) -> Transaction {
         Transaction {

--- a/src/async.rs
+++ b/src/async.rs
@@ -136,6 +136,20 @@ impl AsyncClient {
         Ok(header)
     }
 
+    /// Returns the 10 newest blocks starting at the tip or at start_height if specified.
+    pub async fn get_recent_blocks(
+        &self,
+        start_height: Option<u32>,
+    ) -> Result<Vec<crate::api::Block>, Error> {
+        let url = if let Some(start_height) = start_height {
+            format!("{}/blocks/{}", &self.url, start_height)
+        } else {
+            format!("{}/blocks", &self.url)
+        };
+        let response = self.client.get(&url).send().await?;
+        Ok(response.error_for_status()?.json().await?)
+    }
+
     /// Get the [`BlockStatus`] given a particular [`BlockHash`].
     pub async fn get_block_status(&self, block_hash: &BlockHash) -> Result<BlockStatus, Error> {
         let resp = self

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -150,6 +150,21 @@ impl BlockingClient {
         }
     }
 
+    /// Returns the 10 newest blocks starting at the tip or at start_height if specified.
+    pub fn get_recent_blocks(
+        &self,
+        start_height: Option<u32>,
+    ) -> Result<Vec<crate::api::Block>, Error> {
+        let url = if let Some(start_height) = start_height {
+            format!("{}/blocks/{}", &self.url, start_height)
+        } else {
+            format!("{}/blocks", &self.url)
+        };
+        let response = self.agent.get(&url).call()?;
+        let blocks: Vec<crate::api::Block> = response.into_json()?;
+        Ok(blocks)
+    }
+
     /// Get the [`BlockStatus`] given a particular [`BlockHash`].
     pub fn get_block_status(&self, block_hash: &BlockHash) -> Result<BlockStatus, Error> {
         let resp = self


### PR DESCRIPTION
This adds a new api `get_recent_blocks` that returns the last 10 block heights and hash, with an optional starting height.

Following https://github.com/Blockstream/esplora/blob/master/API.md#get-blocksstart_height

This is required in bdk_core esplora syncing..

Dependent PR : <TODO>