### PR TITLE
Derive `Clone` and implement `{url, client}` for `AsyncClient`

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -26,7 +26,7 @@ use reqwest::{Client, StatusCode};
 
 use crate::{BlockStatus, BlockSummary, Builder, Error, MerkleProof, OutputStatus, Tx, TxStatus};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AsyncClient {
     url: String,
     client: Client,
@@ -322,5 +322,15 @@ impl AsyncClient {
             .error_for_status()?
             .json()
             .await?)
+    }
+
+    /// Get the underlying base URL.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Get the underlying [`Client`].
+    pub fn client(&self) -> &Client {
+        &self.client
     }
 }

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -357,6 +357,16 @@ impl BlockingClient {
 
         Ok(self.agent.get(&url).call()?.into_json()?)
     }
+
+    /// Get the underlying base URL.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Get the underlying [`Agent`].
+    pub fn agent(&self) -> &Agent {
+        &self.agent
+    }
 }
 
 fn is_status_not_found(status: u16) -> bool {


### PR DESCRIPTION
Summary:
 - `#[derive(Clone)]` for `AsyncClient` so that it can now be cloned. The implementation should be cheap because `reqwest::Client` is wrapped in `Arc` automatically, and the `url` field should not be large either.
 - Add the `{url, client}` getters. They are helpful when you want to obtain data from which `AsyncClient` was constructed and don't want to pass these parameters around your code.