### PR TITLE
Leave `rust-bitcoin` compilation flags untouched

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-bitcoin = { version = "0.29.1", features = ["serde"] }
+bitcoin = { version = "0.29.1", features = ["serde"], default-features = false }
 log = "^0.4"
 ureq = { version = "2.5.0", features = ["json"], optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }


### PR DESCRIPTION
Because `wasm_bindgen` enables a hobbled `std` mode by default (where you can "use" the full std, but random bits of it panic), `wasm_bindgen` users really should use `no_std` builds where possible. However, cargo makes this very difficult - crates with `no_std` flags can be silently made `std` just by one dependency setting the flag silently.

This happens here by leaving default-features enabled. Luckily, we can simply disable `default-features` and everything else remains.