### PR TITLE
Disable default features for rust-bitcoin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-bitcoin = { version = "0.29.1", features = ["serde"] }
+bitcoin = { version = "0.29.1", default-features = false, features = ["serde"] }
 log = "^0.4"
 ureq = { version = "2.5.0", features = ["json"], optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }


### PR DESCRIPTION
This shouldnt be needed and will let this be used better in wasm contexts because often you need the no-std version of libraries due to system time.