### PR TITLE
feat(api): expose bitcoin types for the API

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2,8 +2,9 @@
 //!
 //! see: <https://github.com/Blockstream/esplora/blob/master/API.md>
 
-use bitcoin::hashes::hex::FromHex;
-use bitcoin::{BlockHash, OutPoint, Script, Transaction, TxIn, TxOut, Txid, Witness};
+pub use bitcoin::consensus::{deserialize, serialize};
+pub use bitcoin::hashes::hex::FromHex;
+pub use bitcoin::{BlockHash, OutPoint, Script, Transaction, TxIn, TxOut, Txid, Witness};
 
 use serde::Deserialize;
 


### PR DESCRIPTION
In some cases, you need to use the bitcoin primitive to convert a type into another format or build a type from a hex string.

This commit will reexport the primitive used in the client without forcing the caller to add the bitcoin crate as direct dependency.

The motivation to have this is when you are interacting with a system that is not rust, and you do not need the rust-bitcoin.