### PR TITLE
bugfix: `GET /tx/:txid/status` is not `Option`

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -99,18 +99,14 @@ impl AsyncClient {
     }
 
     /// Get the status of a [`Transaction`] given its [`Txid`].
-    pub async fn get_tx_status(&self, txid: &Txid) -> Result<Option<TxStatus>, Error> {
+    pub async fn get_tx_status(&self, txid: &Txid) -> Result<TxStatus, Error> {
         let resp = self
             .client
             .get(&format!("{}/tx/{}/status", self.url, txid))
             .send()
             .await?;
 
-        if let StatusCode::NOT_FOUND = resp.status() {
-            return Ok(None);
-        }
-
-        Ok(Some(resp.error_for_status()?.json().await?))
+        Ok(resp.error_for_status()?.json().await?)
     }
 
     #[deprecated(

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -108,20 +108,15 @@ impl BlockingClient {
     }
 
     /// Get the status of a [`Transaction`] given its [`Txid`].
-    pub fn get_tx_status(&self, txid: &Txid) -> Result<Option<TxStatus>, Error> {
+    pub fn get_tx_status(&self, txid: &Txid) -> Result<TxStatus, Error> {
         let resp = self
             .agent
             .get(&format!("{}/tx/{}/status", self.url, txid))
             .call();
 
         match resp {
-            Ok(resp) => Ok(Some(resp.into_json()?)),
-            Err(ureq::Error::Status(code, _)) => {
-                if is_status_not_found(code) {
-                    return Ok(None);
-                }
-                Err(Error::HttpResponse(code))
-            }
+            Ok(resp) => Ok(resp.into_json()?),
+            Err(ureq::Error::Status(code, _)) => Err(Error::HttpResponse(code)),
             Err(e) => Err(Error::Ureq(e)),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,10 +460,20 @@ mod test {
         let _miner = MINER.lock().await;
         generate_blocks_and_wait(1);
 
-        let tx_status = blocking_client.get_tx_status(&txid).unwrap().unwrap();
-        let tx_status_async = async_client.get_tx_status(&txid).await.unwrap().unwrap();
+        let tx_status = blocking_client.get_tx_status(&txid).unwrap();
+        let tx_status_async = async_client.get_tx_status(&txid).await.unwrap();
         assert_eq!(tx_status, tx_status_async);
         assert!(tx_status.confirmed);
+
+        // Bogus txid returns a TxStatus with false, None, None, None
+        let txid = Txid::hash(b"ayyyy lmao");
+        let tx_status = blocking_client.get_tx_status(&txid).unwrap();
+        let tx_status_async = async_client.get_tx_status(&txid).await.unwrap();
+        assert_eq!(tx_status, tx_status_async);
+        assert!(!tx_status.confirmed);
+        assert!(tx_status.block_height.is_none());
+        assert!(tx_status.block_hash.is_none());
+        assert!(tx_status.block_time.is_none());
     }
 
     #[cfg(all(feature = "blocking", feature = "async"))]


### PR DESCRIPTION
See the [server-side handler](https://github.com/Blockstream/electrs/blob/adedee15f1fe460398a7045b292604df2161adc0/src/rest.rs#L941) - unlike the other `tx` endpoints, this one doesn't first check if the tx is known.

Also added a test that confirms this behavior.