### PR TITLE
Unpin base64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,6 @@ tokio = { version = "1.20.1", features = ["full"] }
 electrsd = { version = "0.22.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_22_0"] }
 electrum-client = "0.12.0"
 lazy_static = "1.4.0"
-# base64 versions after 0.21.0 have MSRV 1.60.0
-base64 = "=0.21.0"
 # zip versions after 0.6.3 don't work with our MSRV 1.57.0
 zip = "=0.6.3"
 # base64ct versions at 1.6.0 and higher have MSRV 1.60.0


### PR DESCRIPTION
base64 lowered the MSRV to 1.57.0 in version 0.21.2