### PR TITLE
Upgrade bitcoin to v0.30.0

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -48,6 +48,9 @@ jobs:
       run: rustup component add clippy
     - name: Update toolchain
       run: rustup update
+    - name: pin dependencies
+      if: ${{ matrix.rust.version }} == 1.57.0
+      run: cargo update -p log --precise 0.4.18 && cargo update -p rustls@0.21.2 --precise 0.21.1
     - name: Build
       run: cargo build --features ${{ matrix.features }} --no-default-features
     - name: Clippy

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -49,8 +49,8 @@ jobs:
     - name: Update toolchain
       run: rustup update
     - name: pin dependencies
-      if: ${{ matrix.rust.version }} == 1.57.0
-      run: cargo update -p log --precise 0.4.18 && cargo update -p rustls@0.21.2 --precise 0.21.1
+      if: matrix.rust.version == '1.57.0'
+      run: cargo update -p log --precise 0.4.18 && cargo update -p rustls:0.21.2 --precise 0.21.1 && cargo update -p time:0.3.15 --precise 0.3.13
     - name: Build
       run: cargo build --features ${{ matrix.features }} --no-default-features
     - name: Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-bitcoin = { version = "0.29.1", features = ["serde"], default-features = false }
+bitcoin = { version = "0.30.0", features = ["serde", "std"], default-features = false }
+# Temporary dependency on internals until the rust-bitcoin devs release the hex-conservative crate.
+bitcoin-internals = { version = "0.1.0", features = ["alloc"] }
 log = "^0.4"
 ureq = { version = "2.5.0", features = ["json"], optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }
@@ -25,8 +27,8 @@ reqwest = { version = "0.11", optional = true, default-features = false, feature
 [dev-dependencies]
 serde_json = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
-electrsd = { version = "0.22.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_22_0"] }
-electrum-client = "0.12.0"
+electrsd = { version = "0.24.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_22_0"] }
+electrum-client = "0.15.1"
 lazy_static = "1.4.0"
 # zip versions after 0.6.3 don't work with our MSRV 1.57.0
 zip = "=0.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ reqwest = { version = "0.11", optional = true, default-features = false, feature
 serde_json = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
 electrsd = { version = "0.24.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_22_0"] }
-electrum-client = "0.15.1"
+electrum-client = "0.15.1"      # When updating to 0.16 remove version number from rustls pin in CI.
 lazy_static = "1.4.0"
 # zip versions after 0.6.3 don't work with our MSRV 1.57.0
 zip = "=0.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ reqwest = { version = "0.11", optional = true, default-features = false, feature
 serde_json = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
 electrsd = { version = "0.24.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_22_0"] }
-electrum-client = "0.15.1"      # When updating to 0.16 remove version number from rustls pin in CI.
+electrum-client = "0.16.0"
 lazy_static = "1.4.0"
 # zip versions after 0.6.3 don't work with our MSRV 1.57.0
 zip = "=0.6.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,6 @@ use std::fmt;
 use std::io;
 
 use bitcoin::consensus;
-use bitcoin::{BlockHash, Txid};
 
 pub mod api;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,10 +224,10 @@ mod test {
         bitcoin::hashes::Hash,
         bitcoin::Amount,
         electrsd::{
-            bitcoind::bitcoincore_rpc::bitcoincore_rpc_json::AddressType,
+            bitcoind::bitcoincore_rpc::json::AddressType,
             bitcoind::bitcoincore_rpc::RpcApi,
+            electrum_client::ElectrumApi,
         },
-        electrum_client::ElectrumApi,
         std::time::Duration,
         tokio::sync::OnceCell,
     };
@@ -292,7 +292,8 @@ mod test {
         let address = BITCOIND
             .client
             .get_new_address(Some("test"), Some(AddressType::Legacy))
-            .unwrap();
+            .unwrap()
+            .assume_checked();
         let _block_hashes = BITCOIND
             .client
             .generate_to_address(num as u64, &address)
@@ -383,7 +384,8 @@ mod test {
         let address = BITCOIND
             .client
             .get_new_address(Some("test"), Some(AddressType::Legacy))
-            .unwrap();
+            .unwrap()
+            .assume_checked();
         let txid = BITCOIND
             .client
             .send_to_address(
@@ -413,7 +415,8 @@ mod test {
         let address = BITCOIND
             .client
             .get_new_address(Some("test"), Some(AddressType::Legacy))
-            .unwrap();
+            .unwrap()
+            .assume_checked();
         let txid = BITCOIND
             .client
             .send_to_address(
@@ -443,7 +446,8 @@ mod test {
         let address = BITCOIND
             .client
             .get_new_address(Some("test"), Some(AddressType::Legacy))
-            .unwrap();
+            .unwrap()
+            .assume_checked();
         let txid = BITCOIND
             .client
             .send_to_address(
@@ -572,7 +576,8 @@ mod test {
         let address = BITCOIND
             .client
             .get_new_address(Some("test"), Some(AddressType::Legacy))
-            .unwrap();
+            .unwrap()
+            .assume_checked();
         let txid = BITCOIND
             .client
             .send_to_address(
@@ -603,7 +608,8 @@ mod test {
         let address = BITCOIND
             .client
             .get_new_address(Some("test"), Some(AddressType::Legacy))
-            .unwrap();
+            .unwrap()
+            .assume_checked();
         let txid = BITCOIND
             .client
             .send_to_address(
@@ -643,7 +649,8 @@ mod test {
         let address = BITCOIND
             .client
             .get_new_address(Some("test"), Some(AddressType::Legacy))
-            .unwrap();
+            .unwrap()
+            .assume_checked();
         let txid = BITCOIND
             .client
             .send_to_address(
@@ -741,7 +748,8 @@ mod test {
         let address = BITCOIND
             .client
             .get_new_address(Some("test"), Some(AddressType::Legacy))
-            .unwrap();
+            .unwrap()
+            .assume_checked();
         let txid = BITCOIND
             .client
             .send_to_address(


### PR DESCRIPTION
Upgrade `rust-bitcoin` to v0.30.3, including:

- bitcoin
- electrsd
- electrum-client

Also includes addition of a dependency on `bitcoin-internals` for the `DisplayHex` trait. This is a temporary fix while we wait for release of the new [`github.com/rust-bitcoin/hex-conservative`](https://github.com/rust-bitcoin/hex-conservative) crate.