### PR TITLE
Remove unused dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,6 @@ tokio = { version = "1.20.1", features = ["full"] }
 electrsd = { version = "0.22.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_22_0"] }
 electrum-client = "0.12.0"
 lazy_static = "1.4.0"
-# zip versions after 0.6.3 don't work with our MSRV 1.57.0
-zip = "=0.6.3"
-# base64ct versions at 1.6.0 and higher have MSRV 1.60.0
-base64ct = "<1.6.0"
 
 [features]
 default = ["blocking", "async", "async-https"]


### PR DESCRIPTION
The two dependencies `zip` and `base64ct` are not used, remove them.

If this was meant as a way to fix the version of these libs we can always pin in CI.