### PR TITLE
refactor(blocking): replace ureq with minreq, update electrsd version

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -53,9 +53,8 @@ jobs:
       run: |
         cargo update -p tokio --precise 1.29.1
         cargo update -p reqwest --precise 0.11.18
-        cargo update -p rustls:0.20.9 --precise 0.20.8
-        cargo update -p rustix --precise 0.38.6
         cargo update -p rustls:0.21.7 --precise 0.21.1
+        cargo update -p rustix --precise 0.38.6
         cargo update -p hyper-rustls:0.24.1 --precise 0.24.0
         cargo update -p rustls-webpki:0.100.3 --precise 0.100.1
         cargo update -p rustls-webpki:0.101.6 --precise 0.101.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 bitcoin = { version = "0.30.0", features = ["serde", "std"], default-features = false }
-# Temporary dependency on internals until the rust-bitcoin devs release the hex-conservative crate.
-bitcoin-internals = { version = "0.1.0", features = ["alloc"] }
+hex-conservative = { version = "0.1"}
 log = "^0.4"
 ureq = { version = "2.5.0", features = ["json"], optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,13 @@ serde = { version = "1.0", features = ["derive"] }
 bitcoin = { version = "0.30.0", features = ["serde", "std"], default-features = false }
 hex-conservative = { version = "0.1"}
 log = "^0.4"
-ureq = { version = "2.5.0", features = ["json"], optional = true }
+minreq = { version = "2.10.0", features = ["json-using-serde"], optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }
 
 [dev-dependencies]
 serde_json = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
-electrsd = { version = "0.24.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_22_0"] }
-electrum-client = "0.16.0"
+electrsd = { version = "0.25.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_22_1"] }
 lazy_static = "1.4.0"
 # zip versions after 0.6.3 don't work with our MSRV 1.57.0
 zip = "=0.6.3"
@@ -36,7 +35,7 @@ base64ct = "<1.6.0"
 
 [features]
 default = ["blocking", "async", "async-https"]
-blocking = ["ureq", "ureq/socks-proxy"]
+blocking = ["minreq", "minreq/proxy"]
 async = ["reqwest", "reqwest/socks"]
 async-https = ["async", "reqwest/default-tls"]
 async-https-native = ["async", "reqwest/native-tls"]

--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ To build with the MSRV you will need to pin dependencies as follows:
 ```shell
 cargo update -p tokio --precise 1.29.1
 cargo update -p reqwest --precise 0.11.18
-cargo update -p rustls:0.20.9 --precise 0.20.8
-cargo update -p rustix --precise 0.38.6
 cargo update -p rustls:0.21.7 --precise 0.21.1
+cargo update -p rustix --precise 0.38.6
 cargo update -p hyper-rustls:0.24.1 --precise 0.24.0
 cargo update -p rustls-webpki:0.100.3 --precise 0.100.1
 cargo update -p rustls-webpki:0.101.6 --precise 0.101.1

--- a/src/async.rs
+++ b/src/async.rs
@@ -132,16 +132,6 @@ impl AsyncClient {
         }
     }
 
-    #[deprecated(
-        since = "0.2.0",
-        note = "Deprecated to improve alignment with Esplora API. Users should use `get_block_hash` and `get_header_by_hash` methods directly."
-    )]
-    /// Get a [`BlockHeader`] given a particular block height.
-    pub async fn get_header(&self, block_height: u32) -> Result<BlockHeader, Error> {
-        let block_hash = self.get_block_hash(block_height).await?;
-        self.get_header_by_hash(&block_hash).await
-    }
-
     /// Get a [`BlockHeader`] given a particular block hash.
     pub async fn get_header_by_hash(&self, block_hash: &BlockHash) -> Result<BlockHeader, Error> {
         let resp = self

--- a/src/async.rs
+++ b/src/async.rs
@@ -17,7 +17,9 @@ use std::str::FromStr;
 use bitcoin::consensus::{deserialize, serialize};
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::hashes::{sha256, Hash};
-use bitcoin::{Block, BlockHash, block::Header as BlockHeader, MerkleBlock, Script, Transaction, Txid};
+use bitcoin::{
+    block::Header as BlockHeader, Block, BlockHash, MerkleBlock, Script, Transaction, Txid,
+};
 use hex_conservative::DisplayHex;
 
 #[allow(unused_imports)]

--- a/src/async.rs
+++ b/src/async.rs
@@ -17,10 +17,8 @@ use std::str::FromStr;
 use bitcoin::consensus::{deserialize, serialize};
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::hashes::{sha256, Hash};
-use bitcoin::{
-    block::Header as BlockHeader, Block, BlockHash, MerkleBlock, Script, Transaction, Txid,
-};
-use bitcoin_internals::hex::display::DisplayHex;
+use bitcoin::{Block, BlockHash, block::Header as BlockHeader, MerkleBlock, Script, Transaction, Txid};
+use hex_conservative::DisplayHex;
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -9,21 +9,18 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
-//! Esplora by way of `ureq` HTTP client.
+//! Esplora by way of `minreq` HTTP client.
 
 use std::collections::HashMap;
-use std::io;
-use std::io::Read;
+use std::convert::TryFrom;
 use std::str::FromStr;
-use std::time::Duration;
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};
 
-use ureq::{Agent, Proxy, Response};
+use minreq::{Proxy, Request};
 
-use bitcoin::consensus::{deserialize, serialize};
-use bitcoin::hashes::hex::FromHex;
+use bitcoin::consensus::{deserialize, serialize, Decodable};
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::{
     block::Header as BlockHeader, Block, BlockHash, MerkleBlock, Script, Transaction, Txid,
@@ -31,55 +28,156 @@ use bitcoin::{
 
 use hex_conservative::DisplayHex;
 
-use crate::{BlockStatus, BlockSummary, Builder, Error, MerkleProof, OutputStatus, Tx, TxStatus};
+use crate::{
+    BlockStatus, BlockSummary, Builder, Error, FromHex, MerkleProof, OutputStatus, Tx, TxStatus,
+};
 
 #[derive(Debug, Clone)]
 pub struct BlockingClient {
     url: String,
-    agent: Agent,
+    /// The proxy is ignored when targeting `wasm32`.
+    pub proxy: Option<String>,
+    /// Socket timeout.
+    pub timeout: Option<u64>,
 }
 
 impl BlockingClient {
     /// build a blocking client from a [`Builder`]
-    pub fn from_builder(builder: Builder) -> Result<Self, Error> {
-        let mut agent_builder = ureq::AgentBuilder::new();
-
-        if let Some(timeout) = builder.timeout {
-            agent_builder = agent_builder.timeout(Duration::from_secs(timeout));
+    pub fn from_builder(builder: Builder) -> Self {
+        Self {
+            url: builder.base_url,
+            proxy: builder.proxy,
+            timeout: builder.timeout,
         }
-
-        if let Some(proxy) = &builder.proxy {
-            agent_builder = agent_builder.proxy(Proxy::new(proxy)?);
-        }
-
-        Ok(Self::from_agent(builder.base_url, agent_builder.build()))
     }
 
-    /// build a blocking client from an [`Agent`]
-    pub fn from_agent(url: String, agent: Agent) -> Self {
-        BlockingClient { url, agent }
+    fn get_request(&self, path: &str) -> Result<Request, Error> {
+        let mut request = minreq::get(format!("{}{}", self.url, path));
+
+        if let Some(proxy) = &self.proxy {
+            let proxy = Proxy::new(proxy.as_str())?;
+            request = request.with_proxy(proxy);
+        }
+
+        if let Some(timeout) = &self.timeout {
+            request = request.with_timeout(*timeout);
+        }
+
+        Ok(request)
+    }
+
+    fn get_opt_response<T: Decodable>(&self, path: &str) -> Result<Option<T>, Error> {
+        match self.get_request(path)?.send() {
+            Ok(resp) if is_status_not_found(resp.status_code) => Ok(None),
+            Ok(resp) if !is_status_ok(resp.status_code) => {
+                let status = u16::try_from(resp.status_code).map_err(Error::StatusCode)?;
+                let message = resp.as_str().unwrap_or_default().to_string();
+                Err(Error::HttpResponse { status, message })
+            }
+            Ok(resp) => Ok(Some(deserialize::<T>(resp.as_bytes())?)),
+            Err(e) => Err(Error::Minreq(e)),
+        }
+    }
+
+    fn get_opt_response_txid(&self, path: &str) -> Result<Option<Txid>, Error> {
+        match self.get_request(path)?.send() {
+            Ok(resp) if is_status_not_found(resp.status_code) => Ok(None),
+            Ok(resp) if !is_status_ok(resp.status_code) => {
+                let status = u16::try_from(resp.status_code).map_err(Error::StatusCode)?;
+                let message = resp.as_str().unwrap_or_default().to_string();
+                Err(Error::HttpResponse { status, message })
+            }
+            Ok(resp) => Ok(Some(
+                Txid::from_str(resp.as_str().map_err(Error::Minreq)?).map_err(Error::Hex)?,
+            )),
+            Err(e) => Err(Error::Minreq(e)),
+        }
+    }
+
+    fn get_opt_response_hex<T: Decodable>(&self, path: &str) -> Result<Option<T>, Error> {
+        match self.get_request(path)?.send() {
+            Ok(resp) if is_status_not_found(resp.status_code) => Ok(None),
+            Ok(resp) if !is_status_ok(resp.status_code) => {
+                let status = u16::try_from(resp.status_code).map_err(Error::StatusCode)?;
+                let message = resp.as_str().unwrap_or_default().to_string();
+                Err(Error::HttpResponse { status, message })
+            }
+            Ok(resp) => {
+                let hex_str = resp.as_str().map_err(Error::Minreq)?;
+                let hex_vec = Vec::from_hex(hex_str).unwrap();
+                deserialize::<T>(&hex_vec)
+                    .map_err(Error::BitcoinEncoding)
+                    .map(|r| Some(r))
+            }
+            Err(e) => Err(Error::Minreq(e)),
+        }
+    }
+
+    // Ok(deserialize(&Vec::from_hex(&resp.into_string()?)?)?),
+    fn get_response_hex<T: Decodable>(&self, path: &str) -> Result<T, Error> {
+        match self.get_request(path)?.send() {
+            Ok(resp) if !is_status_ok(resp.status_code) => {
+                let status = u16::try_from(resp.status_code).map_err(Error::StatusCode)?;
+                let message = resp.as_str().unwrap_or_default().to_string();
+                Err(Error::HttpResponse { status, message })
+            }
+            Ok(resp) => {
+                let hex_str = resp.as_str().map_err(Error::Minreq)?;
+                let hex_vec = Vec::from_hex(hex_str).unwrap();
+                deserialize::<T>(&hex_vec).map_err(Error::BitcoinEncoding)
+            }
+            Err(e) => Err(Error::Minreq(e)),
+        }
+    }
+
+    fn get_response_json<'a, T: serde::de::DeserializeOwned>(
+        &'a self,
+        path: &'a str,
+    ) -> Result<T, Error> {
+        let response = self.get_request(path)?.send();
+        dbg!(&response);
+        match response {
+            Ok(resp) if !is_status_ok(resp.status_code) => {
+                let status = u16::try_from(resp.status_code).map_err(Error::StatusCode)?;
+                let message = resp.as_str().unwrap_or_default().to_string();
+                Err(Error::HttpResponse { status, message })
+            }
+            Ok(resp) => Ok(resp.json::<T>().map_err(Error::Minreq)?),
+            Err(e) => Err(Error::Minreq(e)),
+        }
+    }
+
+    fn get_opt_response_json<T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+    ) -> Result<Option<T>, Error> {
+        match self.get_request(path)?.send() {
+            Ok(resp) if is_status_not_found(resp.status_code) => Ok(None),
+            Ok(resp) if !is_status_ok(resp.status_code) => {
+                let status = u16::try_from(resp.status_code).map_err(Error::StatusCode)?;
+                let message = resp.as_str().unwrap_or_default().to_string();
+                Err(Error::HttpResponse { status, message })
+            }
+            Ok(resp) => Ok(Some(resp.json::<T>()?)),
+            Err(e) => Err(Error::Minreq(e)),
+        }
+    }
+
+    fn get_response_str(&self, path: &str) -> Result<String, Error> {
+        match self.get_request(path)?.send() {
+            Ok(resp) if !is_status_ok(resp.status_code) => {
+                let status = u16::try_from(resp.status_code).map_err(Error::StatusCode)?;
+                let message = resp.as_str().unwrap_or_default().to_string();
+                Err(Error::HttpResponse { status, message })
+            }
+            Ok(resp) => Ok(resp.as_str()?.to_string()),
+            Err(e) => Err(Error::Minreq(e)),
+        }
     }
 
     /// Get a [`Transaction`] option given its [`Txid`]
     pub fn get_tx(&self, txid: &Txid) -> Result<Option<Transaction>, Error> {
-        let resp = self
-            .agent
-            .get(&format!("{}/tx/{}/raw", self.url, txid))
-            .call();
-
-        match resp {
-            Ok(resp) => Ok(Some(deserialize(&into_bytes(resp)?)?)),
-            Err(ureq::Error::Status(code, resp)) => {
-                if is_status_not_found(code) {
-                    return Ok(None);
-                }
-                Err(Error::HttpResponse {
-                    status: code,
-                    message: resp.into_string()?,
-                })
-            }
-            Err(e) => Err(Error::Ureq(e)),
-        }
+        self.get_opt_response(&format!("/tx/{}/raw", txid))
     }
 
     /// Get a [`Transaction`] given its [`Txid`].
@@ -97,41 +195,12 @@ impl BlockingClient {
         block_hash: &BlockHash,
         index: usize,
     ) -> Result<Option<Txid>, Error> {
-        let resp = self
-            .agent
-            .get(&format!("{}/block/{}/txid/{}", self.url, block_hash, index))
-            .call();
-
-        match resp {
-            Ok(resp) => Ok(Some(Txid::from_str(&resp.into_string()?)?)),
-            Err(ureq::Error::Status(code, resp)) => {
-                if is_status_not_found(code) {
-                    return Ok(None);
-                }
-                Err(Error::HttpResponse {
-                    status: code,
-                    message: resp.into_string()?,
-                })
-            }
-            Err(e) => Err(Error::Ureq(e)),
-        }
+        self.get_opt_response_txid(&format!("/block/{}/txid/{}", block_hash, index))
     }
 
     /// Get the status of a [`Transaction`] given its [`Txid`].
     pub fn get_tx_status(&self, txid: &Txid) -> Result<TxStatus, Error> {
-        let resp = self
-            .agent
-            .get(&format!("{}/tx/{}/status", self.url, txid))
-            .call();
-
-        match resp {
-            Ok(resp) => Ok(resp.into_json()?),
-            Err(ureq::Error::Status(code, resp)) => Err(Error::HttpResponse {
-                status: code,
-                message: resp.into_string()?,
-            }),
-            Err(e) => Err(Error::Ureq(e)),
-        }
+        self.get_response_json(&format!("/tx/{}/status", txid))
     }
 
     /// Get a [`BlockHeader`] given a particular block height.
@@ -146,102 +215,27 @@ impl BlockingClient {
 
     /// Get a [`BlockHeader`] given a particular block hash.
     pub fn get_header_by_hash(&self, block_hash: &BlockHash) -> Result<BlockHeader, Error> {
-        let resp = self
-            .agent
-            .get(&format!("{}/block/{}/header", self.url, block_hash))
-            .call();
-
-        match resp {
-            Ok(resp) => Ok(deserialize(&Vec::from_hex(&resp.into_string()?)?)?),
-            Err(ureq::Error::Status(code, resp)) => Err(Error::HttpResponse {
-                status: code,
-                message: resp.into_string()?,
-            }),
-            Err(e) => Err(Error::Ureq(e)),
-        }
+        self.get_response_hex(&format!("/block/{}/header", block_hash))
     }
 
     /// Get the [`BlockStatus`] given a particular [`BlockHash`].
     pub fn get_block_status(&self, block_hash: &BlockHash) -> Result<BlockStatus, Error> {
-        let resp = self
-            .agent
-            .get(&format!("{}/block/{}/status", self.url, block_hash))
-            .call();
-
-        match resp {
-            Ok(resp) => Ok(resp.into_json()?),
-            Err(ureq::Error::Status(code, resp)) => Err(Error::HttpResponse {
-                status: code,
-                message: resp.into_string()?,
-            }),
-            Err(e) => Err(Error::Ureq(e)),
-        }
+        self.get_response_json(&format!("/block/{}/status", block_hash))
     }
 
     /// Get a [`Block`] given a particular [`BlockHash`].
     pub fn get_block_by_hash(&self, block_hash: &BlockHash) -> Result<Option<Block>, Error> {
-        let resp = self
-            .agent
-            .get(&format!("{}/block/{}/raw", self.url, block_hash))
-            .call();
-
-        match resp {
-            Ok(resp) => Ok(Some(deserialize(&into_bytes(resp)?)?)),
-            Err(ureq::Error::Status(code, resp)) => {
-                if is_status_not_found(code) {
-                    return Ok(None);
-                }
-                Err(Error::HttpResponse {
-                    status: code,
-                    message: resp.into_string()?,
-                })
-            }
-            Err(e) => Err(Error::Ureq(e)),
-        }
+        self.get_opt_response(&format!("/block/{}/raw", block_hash))
     }
 
     /// Get a merkle inclusion proof for a [`Transaction`] with the given [`Txid`].
     pub fn get_merkle_proof(&self, txid: &Txid) -> Result<Option<MerkleProof>, Error> {
-        let resp = self
-            .agent
-            .get(&format!("{}/tx/{}/merkle-proof", self.url, txid))
-            .call();
-
-        match resp {
-            Ok(resp) => Ok(Some(resp.into_json()?)),
-            Err(ureq::Error::Status(code, resp)) => {
-                if is_status_not_found(code) {
-                    return Ok(None);
-                }
-                Err(Error::HttpResponse {
-                    status: code,
-                    message: resp.into_string()?,
-                })
-            }
-            Err(e) => Err(Error::Ureq(e)),
-        }
+        self.get_opt_response_json(&format!("/tx/{}/merkle-proof", txid))
     }
 
     /// Get a [`MerkleBlock`] inclusion proof for a [`Transaction`] with the given [`Txid`].
     pub fn get_merkle_block(&self, txid: &Txid) -> Result<Option<MerkleBlock>, Error> {
-        let resp = self
-            .agent
-            .get(&format!("{}/tx/{}/merkleblock-proof", self.url, txid))
-            .call();
-
-        match resp {
-            Ok(resp) => Ok(Some(deserialize(&Vec::from_hex(&resp.into_string()?)?)?)),
-            Err(ureq::Error::Status(code, resp)) => {
-                if is_status_not_found(code) {
-                    return Ok(None);
-                }
-                Err(Error::HttpResponse {
-                    status: code,
-                    message: resp.into_string()?,
-                })
-            }
-            Err(e) => Err(Error::Ureq(e)),
-        }
+        self.get_opt_response_hex(&format!("/tx/{}/merkleblock-proof", txid))
     }
 
     /// Get the spending status of an output given a [`Txid`] and the output index.
@@ -250,118 +244,60 @@ impl BlockingClient {
         txid: &Txid,
         index: u64,
     ) -> Result<Option<OutputStatus>, Error> {
-        let resp = self
-            .agent
-            .get(&format!("{}/tx/{}/outspend/{}", self.url, txid, index))
-            .call();
-
-        match resp {
-            Ok(resp) => Ok(Some(resp.into_json()?)),
-            Err(ureq::Error::Status(code, resp)) => {
-                if is_status_not_found(code) {
-                    return Ok(None);
-                }
-                Err(Error::HttpResponse {
-                    status: code,
-                    message: resp.into_string()?,
-                })
-            }
-            Err(e) => Err(Error::Ureq(e)),
-        }
+        self.get_opt_response_json(&format!("/tx/{}/outspend/{}", txid, index))
     }
 
     /// Broadcast a [`Transaction`] to Esplora
     pub fn broadcast(&self, transaction: &Transaction) -> Result<(), Error> {
-        let resp = self
-            .agent
-            .post(&format!("{}/tx", self.url))
-            .send_string(&serialize(transaction).to_lower_hex_string());
+        let mut request = minreq::post(format!("{}/tx", self.url)).with_body(
+            serialize(transaction)
+                .to_lower_hex_string()
+                .as_bytes()
+                .to_vec(),
+        );
 
-        match resp {
-            Ok(_) => Ok(()), // We do not return the txid?
-            Err(ureq::Error::Status(code, resp)) => Err(Error::HttpResponse {
-                status: code,
-                message: resp.into_string()?,
-            }),
-            Err(e) => Err(Error::Ureq(e)),
+        if let Some(proxy) = &self.proxy {
+            let proxy = Proxy::new(proxy.as_str())?;
+            request = request.with_proxy(proxy);
+        }
+
+        if let Some(timeout) = &self.timeout {
+            request = request.with_timeout(*timeout);
+        }
+
+        match request.send() {
+            Ok(resp) if !is_status_ok(resp.status_code) => {
+                let status = u16::try_from(resp.status_code).map_err(Error::StatusCode)?;
+                let message = resp.as_str().unwrap_or_default().to_string();
+                Err(Error::HttpResponse { status, message })
+            }
+            Ok(_resp) => Ok(()),
+            Err(e) => Err(Error::Minreq(e)),
         }
     }
 
     /// Get the height of the current blockchain tip.
     pub fn get_height(&self) -> Result<u32, Error> {
-        let resp = self
-            .agent
-            .get(&format!("{}/blocks/tip/height", self.url))
-            .call();
-
-        match resp {
-            Ok(resp) => Ok(resp.into_string()?.parse()?),
-            Err(ureq::Error::Status(code, resp)) => Err(Error::HttpResponse {
-                status: code,
-                message: resp.into_string()?,
-            }),
-            Err(e) => Err(Error::Ureq(e)),
-        }
+        self.get_response_str("/blocks/tip/height")
+            .map(|s| u32::from_str(s.as_str()).map_err(Error::Parsing))?
     }
 
     /// Get the [`BlockHash`] of the current blockchain tip.
     pub fn get_tip_hash(&self) -> Result<BlockHash, Error> {
-        let resp = self
-            .agent
-            .get(&format!("{}/blocks/tip/hash", self.url))
-            .call();
-
-        Self::process_block_result(resp)
+        self.get_response_str("/blocks/tip/hash")
+            .map(|s| BlockHash::from_str(s.as_str()).map_err(Error::Hex))?
     }
 
     /// Get the [`BlockHash`] of a specific block height
     pub fn get_block_hash(&self, block_height: u32) -> Result<BlockHash, Error> {
-        let resp = self
-            .agent
-            .get(&format!("{}/block-height/{}", self.url, block_height))
-            .call();
-
-        if let Err(ureq::Error::Status(code, _)) = resp {
-            if is_status_not_found(code) {
-                return Err(Error::HeaderHeightNotFound(block_height));
-            }
-        }
-
-        Self::process_block_result(resp)
-    }
-
-    fn process_block_result(response: Result<Response, ureq::Error>) -> Result<BlockHash, Error> {
-        match response {
-            Ok(resp) => Ok(BlockHash::from_str(&resp.into_string()?)?),
-            Err(ureq::Error::Status(code, resp)) => Err(Error::HttpResponse {
-                status: code,
-                message: resp.into_string()?,
-            }),
-            Err(e) => Err(Error::Ureq(e)),
-        }
+        self.get_response_str(&format!("/block-height/{}", block_height))
+            .map(|s| BlockHash::from_str(s.as_str()).map_err(Error::Hex))?
     }
 
     /// Get an map where the key is the confirmation target (in number of blocks)
     /// and the value is the estimated feerate (in sat/vB).
     pub fn get_fee_estimates(&self) -> Result<HashMap<String, f64>, Error> {
-        let resp = self
-            .agent
-            .get(&format!("{}/fee-estimates", self.url,))
-            .call();
-
-        let map = match resp {
-            Ok(resp) => {
-                let map: HashMap<String, f64> = resp.into_json()?;
-                Ok(map)
-            }
-            Err(ureq::Error::Status(code, resp)) => Err(Error::HttpResponse {
-                status: code,
-                message: resp.into_string()?,
-            }),
-            Err(e) => Err(Error::Ureq(e)),
-        }?;
-
-        Ok(map)
+        self.get_response_json("/fee-estimates")
     }
 
     /// Get confirmed transaction history for the specified address/scripthash,
@@ -373,14 +309,11 @@ impl BlockingClient {
         last_seen: Option<Txid>,
     ) -> Result<Vec<Tx>, Error> {
         let script_hash = sha256::Hash::hash(script.as_bytes());
-        let url = match last_seen {
-            Some(last_seen) => format!(
-                "{}/scripthash/{:x}/txs/chain/{}",
-                self.url, script_hash, last_seen
-            ),
-            None => format!("{}/scripthash/{:x}/txs", self.url, script_hash),
+        let path = match last_seen {
+            Some(last_seen) => format!("/scripthash/{:x}/txs/chain/{}", script_hash, last_seen),
+            None => format!("/scripthash/{:x}/txs", script_hash),
         };
-        Ok(self.agent.get(&url).call()?.into_json()?)
+        self.get_response_json(&path)
     }
 
     /// Gets some recent block summaries starting at the tip or at `height` if provided.
@@ -388,57 +321,18 @@ impl BlockingClient {
     /// The maximum number of summaries returned depends on the backend itself: esplora returns `10`
     /// while [mempool.space](https://mempool.space/docs/api) returns `15`.
     pub fn get_blocks(&self, height: Option<u32>) -> Result<Vec<BlockSummary>, Error> {
-        let url = match height {
-            Some(height) => format!("{}/blocks/{}", self.url, height),
-            None => format!("{}/blocks", self.url),
+        let path = match height {
+            Some(height) => format!("/blocks/{}", height),
+            None => "/blocks".to_string(),
         };
-
-        Ok(self.agent.get(&url).call()?.into_json()?)
-    }
-
-    /// Get the underlying base URL.
-    pub fn url(&self) -> &str {
-        &self.url
-    }
-
-    /// Get the underlying [`Agent`].
-    pub fn agent(&self) -> &Agent {
-        &self.agent
+        self.get_response_json(&path)
     }
 }
 
-fn is_status_not_found(status: u16) -> bool {
+fn is_status_ok(status: i32) -> bool {
+    status == 200
+}
+
+fn is_status_not_found(status: i32) -> bool {
     status == 404
-}
-
-fn into_bytes(resp: Response) -> Result<Vec<u8>, io::Error> {
-    const BYTES_LIMIT: usize = 10 * 1_024 * 1_024;
-
-    let mut buf: Vec<u8> = vec![];
-    resp.into_reader()
-        .take((BYTES_LIMIT + 1) as u64)
-        .read_to_end(&mut buf)?;
-    if buf.len() > BYTES_LIMIT {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
-            "response too big for into_bytes",
-        ));
-    }
-
-    Ok(buf)
-}
-
-impl From<ureq::Error> for Error {
-    fn from(e: ureq::Error) -> Self {
-        match e {
-            ureq::Error::Status(code, resp) => match resp.into_string() {
-                Ok(msg) => Error::HttpResponse {
-                    status: code,
-                    message: msg,
-                },
-                Err(e) => Error::Io(e),
-            },
-            e => Error::Ureq(e),
-        }
-    }
 }

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -29,7 +29,7 @@ use bitcoin::{
     block::Header as BlockHeader, Block, BlockHash, MerkleBlock, Script, Transaction, Txid,
 };
 
-use bitcoin_internals::hex::display::DisplayHex;
+use hex_conservative::DisplayHex;
 
 use crate::{BlockStatus, BlockSummary, Builder, Error, MerkleProof, OutputStatus, Tx, TxStatus};
 

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -203,16 +203,6 @@ impl BlockingClient {
         self.get_response_json(&format!("/tx/{}/status", txid))
     }
 
-    /// Get a [`BlockHeader`] given a particular block height.
-    #[deprecated(
-        since = "0.2.0",
-        note = "Deprecated to improve alignment with Esplora API. Users should use `get_block_hash` and `get_header_by_hash` methods directly."
-    )]
-    pub fn get_header(&self, block_height: u32) -> Result<BlockHeader, Error> {
-        let block_hash = self.get_block_hash(block_height)?;
-        self.get_header_by_hash(&block_hash)
-    }
-
     /// Get a [`BlockHeader`] given a particular block hash.
     pub fn get_header_by_hash(&self, block_hash: &BlockHash) -> Result<BlockHeader, Error> {
         self.get_response_hex(&format!("/block/{}/header", block_hash))


### PR DESCRIPTION
Since `ureq` still doesn't have an MSRV this PR refactors the blocking esplora client to use `minreq`. 

I also replaced the dependency `bitcoin-internals` with the new `hex-conservative` crate.

