### PR TITLE
fix(wallet_esplora): Gracefully handle 429s errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,28 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-bitcoin = { version = "0.30.0", features = ["serde", "std"], default-features = false }
+bitcoin = { version = "0.30.0", features = [
+    "serde",
+    "std",
+], default-features = false }
 # Temporary dependency on internals until the rust-bitcoin devs release the hex-conservative crate.
 bitcoin-internals = { version = "0.1.0", features = ["alloc"] }
 log = "^0.4"
 ureq = { version = "2.5.0", features = ["json"], optional = true }
-reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }
+reqwest = { version = "0.11", optional = true, default-features = false, features = [
+    "json",
+] }
+tokio = { version = "1", features = ["time"], optional = true }
+async-recursion = { version = "1", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
-electrsd = { version = "0.24.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_22_0"] }
+electrsd = { version = "0.24.0", features = [
+    "legacy",
+    "esplora_a33e97e1",
+    "bitcoind_22_0",
+] }
 electrum-client = "0.16.0"
 lazy_static = "1.4.0"
 # zip versions after 0.6.3 don't work with our MSRV 1.57.0
@@ -38,7 +49,7 @@ base64ct = "<1.6.0"
 [features]
 default = ["blocking", "async", "async-https"]
 blocking = ["ureq", "ureq/socks-proxy"]
-async = ["reqwest", "reqwest/socks"]
+async = ["reqwest", "reqwest/socks", "tokio/time", "async-recursion"]
 async-https = ["async", "reqwest/default-tls"]
 async-https-native = ["async", "reqwest/native-tls"]
 async-https-rustls = ["async", "reqwest/rustls-tls"]


### PR DESCRIPTION
Closes https://github.com/bitcoindevkit/bdk/issues/1120

## Details

- `BlockingClient`:
  - Add an extra check inside `scripthash_txs` for 429 Status codes.
    If detected, hard-coded sleep for 500ms using `std::thread::sleep` (so it is also thread-safe).
- `AsyncClient` (little more convoluted than `BlockingClient`):
  - I had to bring `tokio` and `async-recursion` into the `dependencies`.
  - Inside the `scripthash_txs` we are checking for 429 Status codes.
    If detected, hard-coded sleep for 500ms using `tokio::time::sleep`.
    Since this is an "async recursion" the macro [`async_recursion`](https://docs.rs/async-recursion) handles that gracefully without having to deal with:

    ```rust
    # https://rust-lang.github.io/async-book/07_workarounds/04_recursion.html
    use futures::future::{BoxFuture, FutureExt};

    fn recursive() -> BoxFuture<'static, ()> {
        async move {
            recursive().await;
            recursive().await;
        }.boxed()
    }
    ```

    If we annotate the offending recursive function with `#[async_recursion]`,
    it automatically convert an async function to one returning a boxed `Future`.