### PR TITLE
ci: test WASM

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -28,7 +28,7 @@ jobs:
           - async-https-rustls
           - async-https-rustls-manual-roots
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Generate cache key
       run: echo "${{ matrix.rust.version }} ${{ matrix.features }}" | tee .cache_key
     - name: cache
@@ -72,3 +72,12 @@ jobs:
       run: cargo clippy --all-targets --features ${{ matrix.features }} --no-default-features -- -D warnings
     - name: Test
       run: cargo test --features ${{ matrix.features }} --no-default-features
+
+  check-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - run: cargo check --target wasm32-unknown-unknown --no-default-features --features bitcoin/no-std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,28 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-bitcoin = { version = "0.30.0", features = ["serde", "std"], default-features = false }
+bitcoin = { version = "0.30.0", features = [
+  "serde",
+  "std",
+], default-features = false }
 # Temporary dependency on internals until the rust-bitcoin devs release the hex-conservative crate.
 bitcoin-internals = { version = "0.1.0", features = ["alloc"] }
 log = "^0.4"
 ureq = { version = "2.5.0", features = ["json"], optional = true }
-reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }
+reqwest = { version = "0.11", optional = true, default-features = false, features = [
+  "json",
+] }
+# WASM specific fix
+getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 serde_json = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
-electrsd = { version = "0.24.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_22_0"] }
+electrsd = { version = "0.24.0", features = [
+  "legacy",
+  "esplora_a33e97e1",
+  "bitcoind_22_0",
+] }
 electrum-client = "0.16.0"
 lazy_static = "1.4.0"
 # zip versions after 0.6.3 don't work with our MSRV 1.57.0


### PR DESCRIPTION
Since #59 mentioned that wasm would break under certain circumstances, we have no idea when it will break.
Hence, this PR adds WASM checks in the CI.


From @LLFourn in #59:
> PS are we testing this crate on WASM? If not PR fixing that before this one would be good.