### PR TITLE
fix: change target's type in fee estimate map

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -369,7 +369,7 @@ impl AsyncClient {
 
     /// Get an map where the key is the confirmation target (in number of blocks)
     /// and the value is the estimated feerate (in sat/vB).
-    pub async fn get_fee_estimates(&self) -> Result<HashMap<String, f64>, Error> {
+    pub async fn get_fee_estimates(&self) -> Result<HashMap<u16, f64>, Error> {
         let resp = self
             .client
             .get(&format!("{}/fee-estimates", self.url,))
@@ -382,7 +382,7 @@ impl AsyncClient {
                 message: resp.text().await?,
             })
         } else {
-            Ok(resp.json::<HashMap<String, f64>>().await?)
+            Ok(resp.json::<HashMap<u16, f64>>().await?)
         }
     }
 

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -281,7 +281,7 @@ impl BlockingClient {
 
     /// Get an map where the key is the confirmation target (in number of blocks)
     /// and the value is the estimated feerate (in sat/vB).
-    pub fn get_fee_estimates(&self) -> Result<HashMap<String, f64>, Error> {
+    pub fn get_fee_estimates(&self) -> Result<HashMap<u16, f64>, Error> {
         self.get_response_json("/fee-estimates")
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,16 +88,13 @@ pub use r#async::AsyncClient;
 
 /// Get a fee value in sats/vbytes from the estimates
 /// that matches the confirmation target set as parameter.
-pub fn convert_fee_rate(target: usize, estimates: HashMap<String, f64>) -> Result<f32, Error> {
+pub fn convert_fee_rate(target: usize, estimates: HashMap<u16, f64>) -> Result<f32, Error> {
     let fee_val = {
-        let mut pairs = estimates
-            .into_iter()
-            .filter_map(|(k, v)| Some((k.parse::<usize>().ok()?, v)))
-            .collect::<Vec<_>>();
+        let mut pairs = estimates.into_iter().collect::<Vec<(u16, f64)>>();
         pairs.sort_unstable_by_key(|(k, _)| std::cmp::Reverse(*k));
         pairs
             .into_iter()
-            .find(|(k, _)| k <= &target)
+            .find(|(k, _)| *k as usize <= target)
             .map(|(_, v)| v)
             .unwrap_or(1.0)
     };
@@ -336,7 +333,7 @@ mod test {
 
     #[test]
     fn feerate_parsing() {
-        let esplora_fees = serde_json::from_str::<HashMap<String, f64>>(
+        let esplora_fees = serde_json::from_str::<HashMap<u16, f64>>(
             r#"{
   "25": 1.015,
   "5": 2.3280000000000003,


### PR DESCRIPTION
Fixes #64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the method for fetching fee estimates to use more efficient data types.
	- Improved the fee rate conversion process for enhanced accuracy and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->