### PR TITLE
add http header support

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -36,6 +36,8 @@ pub struct BlockingClient {
     pub proxy: Option<String>,
     /// Socket timeout.
     pub timeout: Option<u64>,
+    /// HTTP headers to set on every request made to Esplora server
+    pub headers: HashMap<String, String>,
 }
 
 impl BlockingClient {
@@ -45,6 +47,7 @@ impl BlockingClient {
             url: builder.base_url,
             proxy: builder.proxy,
             timeout: builder.timeout,
+            headers: builder.headers,
         }
     }
 
@@ -58,6 +61,12 @@ impl BlockingClient {
 
         if let Some(timeout) = &self.timeout {
             request = request.with_timeout(*timeout);
+        }
+
+        if !self.headers.is_empty() {
+            for (key, value) in &self.headers {
+                request = request.with_header(key, value);
+            }
         }
 
         Ok(request)


### PR DESCRIPTION
Technically an end-user could do this themselves because the builders support passing in pre-built ureq/reqwest clients but this makes it a bit easier for them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to set custom HTTP headers for requests in both asynchronous and synchronous clients.
	- Added methods in the `Builder` struct for adding HTTP headers to requests.
- **Improvements**
	- Enhanced error handling with new error variants for invalid HTTP header names and values.
- **Tests**
	- Updated test setup to include custom HTTP headers.
	- Added a new test case for fetching transactions with specific HTTP headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->