### PR TITLE
fix: bump `h2` version to patched one, while reqwest has not been

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bitcoin-internals = { version = "0.1.0", features = ["alloc"] }
 log = "^0.4"
 ureq = { version = "2.5.0", features = ["json"], optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }
+h2 = { version = "^0.3.24", optional = true}
 
 [dev-dependencies]
 serde_json = "1.0"
@@ -35,7 +36,7 @@ lazy_static = "1.4.0"
 [features]
 default = ["blocking", "async", "async-https"]
 blocking = ["ureq", "ureq/socks-proxy"]
-async = ["reqwest", "reqwest/socks"]
+async = ["h2", "reqwest", "reqwest/socks"]
 async-https = ["async", "reqwest/default-tls"]
 async-https-native = ["async", "reqwest/native-tls"]
 async-https-rustls = ["async", "reqwest/rustls-tls"]


### PR DESCRIPTION
patched yet

- check: https://rustsec.org/advisories/RUSTSEC-2024-0003