### PR TITLE
Bump electrsd to 0.26 + bitcoind_25_0 and fix msrv errors

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -44,7 +44,7 @@ jobs:
         # For more info, see:
         # - https://github.com/bitcoindevkit/bdk/issues/696
         # - https://github.com/bitcoindevkit/bdk/pull/748#issuecomment-1242721040
-        run: cargo test
+        run: cargo test -- --test-threads=1
       - name: Run grcov
         run: mkdir coverage; grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore '/*' -o ./coverage/lcov.info
       - name: Generate HTML coverage report

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -51,6 +51,9 @@ jobs:
     - name: pin dependencies
       if: matrix.rust.version == '1.63.0'
       run: |
+        cargo update -p zstd-sys --precise "2.0.8+zstd.1.5.5"
+        cargo update -p time --precise "0.3.20"
+        cargo update -p jobserver --precise "0.1.26"
         cargo update -p home --precise 0.5.5
     - name: Build
       run: cargo build --features ${{ matrix.features }} --no-default-features

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -61,4 +61,4 @@ jobs:
       if: ${{ matrix.rust.clippy }}
       run: cargo clippy --all-targets --features ${{ matrix.features }} --no-default-features -- -D warnings
     - name: Test
-      run: cargo test --features ${{ matrix.features }} --no-default-features
+      run: cargo test --features ${{ matrix.features }} --no-default-features -- --test-threads=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,7 @@ path = "src/lib.rs"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 bitcoin = { version = "0.30.0", features = ["serde", "std"], default-features = false }
-# Temporary dependency on internals until the rust-bitcoin devs release the hex-conservative crate.
-bitcoin-internals = { version = "0.1.0", features = ["alloc"] }
+hex = { package = "hex-conservative", version = "*" }
 log = "^0.4"
 ureq = { version = "2.5.0", features = ["json"], optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,7 @@ reqwest = { version = "0.11", optional = true, default-features = false, feature
 [dev-dependencies]
 serde_json = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
-electrsd = { version = "0.24.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_22_0"] }
-electrum-client = "0.16.0"
+electrsd = { version = "0.26.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_25_0"] }
 lazy_static = "1.4.0"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ This library should compile with any combination of features with Rust 1.63.0.
 To build with the MSRV you will need to pin dependencies as follows:
 
 ```shell
-cargo update -p home --precise 0.5.5
+cargo update -p jobserver --precise "0.1.26"
 ```

--- a/src/async.rs
+++ b/src/async.rs
@@ -20,7 +20,7 @@ use bitcoin::hashes::{sha256, Hash};
 use bitcoin::{
     block::Header as BlockHeader, Block, BlockHash, MerkleBlock, Script, Transaction, Txid,
 };
-use bitcoin_internals::hex::display::DisplayHex;
+use hex::display::DisplayHex;
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -29,7 +29,7 @@ use bitcoin::{
     block::Header as BlockHeader, Block, BlockHash, MerkleBlock, Script, Transaction, Txid,
 };
 
-use bitcoin_internals::hex::display::DisplayHex;
+use hex::display::DisplayHex;
 
 use crate::{BlockStatus, BlockSummary, Builder, Error, MerkleProof, OutputStatus, Tx, TxStatus};
 


### PR DESCRIPTION
This PR bumps electrsd to 0.26 and replaces temporary dependency on `bitcoin-internals` with `hex-conservative` as done in #75. Fixed CI MSRV issues with dev dependencies blocking #75 and #74. 