### PR TITLE
Upgrade bitcoin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esplora-client"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2018"
 authors = ["Alekos Filini <alekos.filini@gmail.com>"]
 license = "MIT"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-bitcoin = { version = "0.30.0", features = ["serde", "std"], default-features = false }
+bitcoin = { version = "0.31.0", features = ["serde", "std"], default-features = false }
 hex = { package = "hex-conservative", version = "*" }
 log = "^0.4"
 ureq = { version = "2.5.0", features = ["json"], optional = true }
@@ -27,7 +27,7 @@ reqwest = { version = "0.11", optional = true, default-features = false, feature
 [dev-dependencies]
 serde_json = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
-electrsd = { version = "0.26.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_25_0"] }
+electrsd = { version = "0.27.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_25_0"] }
 lazy_static = "1.4.0"
 
 [features]

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,8 +3,8 @@
 //! see: <https://github.com/Blockstream/esplora/blob/master/API.md>
 
 pub use bitcoin::consensus::{deserialize, serialize};
-pub use bitcoin::hashes::hex::FromHex;
-pub use bitcoin::{BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid, Witness};
+pub use bitcoin::hex::FromHex;
+pub use bitcoin::{transaction, Amount, BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid, Witness};
 
 use serde::Deserialize;
 
@@ -93,7 +93,7 @@ pub struct BlockSummary {
 impl Tx {
     pub fn to_tx(&self) -> Transaction {
         Transaction {
-            version: self.version,
+            version: transaction::Version::non_standard(self.version),
             lock_time: bitcoin::absolute::LockTime::from_consensus(self.locktime),
             input: self
                 .vin
@@ -114,7 +114,7 @@ impl Tx {
                 .iter()
                 .cloned()
                 .map(|vout| TxOut {
-                    value: vout.value,
+                    value: Amount::from_sat(vout.value),
                     script_pubkey: vout.scriptpubkey,
                 })
                 .collect(),
@@ -140,7 +140,7 @@ impl Tx {
             .map(|vin| {
                 vin.prevout.map(|po| TxOut {
                     script_pubkey: po.scriptpubkey,
-                    value: po.value,
+                    value: Amount::from_sat(po.value),
                 })
             })
             .collect()

--- a/src/async.rs
+++ b/src/async.rs
@@ -15,12 +15,11 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use bitcoin::consensus::{deserialize, serialize};
-use bitcoin::hashes::hex::FromHex;
+use bitcoin::hex::{DisplayHex, FromHex};
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::{
     block::Header as BlockHeader, Block, BlockHash, MerkleBlock, Script, Transaction, Txid,
 };
-use hex::display::DisplayHex;
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -23,13 +23,11 @@ use log::{debug, error, info, trace};
 use ureq::{Agent, Proxy, Response};
 
 use bitcoin::consensus::{deserialize, serialize};
-use bitcoin::hashes::hex::FromHex;
+use bitcoin::hex::{DisplayHex, FromHex};
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::{
     block::Header as BlockHeader, Block, BlockHash, MerkleBlock, Script, Transaction, Txid,
 };
-
-use hex::display::DisplayHex;
 
 use crate::{BlockStatus, BlockSummary, Builder, Error, MerkleProof, OutputStatus, Tx, TxStatus};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,8 +171,10 @@ pub enum Error {
     Parsing(std::num::ParseIntError),
     /// Invalid Bitcoin data returned
     BitcoinEncoding(bitcoin::consensus::encode::Error),
-    /// Invalid Hex data returned
-    Hex(bitcoin::hashes::hex::Error),
+    /// Invalid hex data returned (attempting to create an array)
+    HexToArray(bitcoin::hex::HexToArrayError),
+    /// Invalid hex data returned (attempting to create a vector)
+    HexToBytes(bitcoin::hex::HexToBytesError),
 
     /// Transaction not found
     TransactionNotFound(Txid),
@@ -209,7 +211,8 @@ impl_error!(::reqwest::Error, Reqwest, Error);
 impl_error!(io::Error, Io, Error);
 impl_error!(std::num::ParseIntError, Parsing, Error);
 impl_error!(consensus::encode::Error, BitcoinEncoding, Error);
-impl_error!(bitcoin::hashes::hex::Error, Hex, Error);
+impl_error!(bitcoin::hex::HexToArrayError, HexToArray, Error);
+impl_error!(bitcoin::hex::HexToBytesError, HexToBytes, Error);
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
Upgrade dependencies to use the latest `rust-bitcoin v0.31`.

While we are at it, bump the crate version ready for release.

(Includes pinning dependencies for MSRV build in CI.)