### PR TITLE
fix hex dependency version, set to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 bitcoin = { version = "0.31.0", features = ["serde", "std"], default-features = false }
-hex = { package = "hex-conservative", version = "*" }
+hex = { package = "hex-conservative", version = "0.2" }
 log = "^0.4"
 minreq = { version = "2.11.0", features = ["json-using-serde"], optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }


### PR DESCRIPTION
We need to set a version for the hex dependency, crates.io does not let us publish a package with an * version.