### PR TITLE
Depend on bitcoin `v0.32.0-rc1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esplora-client"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2018"
 authors = ["Alekos Filini <alekos.filini@gmail.com>"]
 license = "MIT"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-bitcoin = { version = "0.31.0", features = ["serde", "std"], default-features = false }
+bitcoin = { version = "0.32.0-rc1", features = ["serde", "std"], default-features = false }
 hex = { package = "hex-conservative", version = "0.2" }
 log = "^0.4"
 minreq = { version = "2.11.0", features = ["json-using-serde"], optional = true }
@@ -27,7 +27,7 @@ reqwest = { version = "0.11", optional = true, default-features = false, feature
 [dev-dependencies]
 serde_json = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
-electrsd = { version = "0.27.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_25_0"] }
+electrsd = { version = "0.28.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_25_0"] }
 lazy_static = "1.4.0"
 
 [features]
@@ -42,3 +42,43 @@ async-https = ["async", "reqwest/default-tls"]
 async-https-native = ["async", "reqwest/native-tls"]
 async-https-rustls = ["async", "reqwest/rustls-tls"]
 async-https-rustls-manual-roots = ["async", "reqwest/rustls-tls-manual-roots"]
+
+[patch.crates-io.bitcoincore-rpc]
+git = "https://github.com/tcharding/rust-bitcoincore-rpc"
+branch = "test-bitcoin"
+
+[patch.crates-io.electrsd]
+git = "https://github.com/tcharding/electrsd"
+branch = "test-bitcoin"
+
+[patch.crates-io.electrum-client]
+git = "https://github.com/tcharding/rust-electrum-client"
+branch = "test-bitcoin"
+
+[patch.crates-io.bitcoind]
+git = "https://github.com/tcharding/bitcoind"
+branch = "test-bitcoin"
+
+[patch.crates-io.base58ck]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin_hashes]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin-internals]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin-io]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin-units]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"


### PR DESCRIPTION
This is not a merge candidate, just for testing the current bitcoin release candidate.

Test the latest bitcoin release candidate. Includes bumping the version numbers so we can use this branch to test crates further up the stack.