### PR TITLE
Add https feature for minreq

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 bitcoin = { version = "0.31.0", features = ["serde", "std"], default-features = false }
 hex = { package = "hex-conservative", version = "0.2" }
 log = "^0.4"
-minreq = { version = "2.11.0", features = ["json-using-serde"], optional = true }
+minreq = { version = "2.11.0", features = ["https", "json-using-serde"], optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }
 
 [dev-dependencies]


### PR DESCRIPTION
`build_blocking` seems to require the `https` feature for `minreq`