### PR TITLE
chore(deps): upgrade `rust-bitcoin` to `0.32.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-bitcoin = { version = "0.31.0", features = ["serde", "std"], default-features = false }
+bitcoin = { version = "0.32", features = ["serde", "std"], default-features = false }
 hex = { package = "hex-conservative", version = "0.2" }
 log = "^0.4"
 minreq = { version = "2.11.0", features = ["json-using-serde"], optional = true }
@@ -27,7 +27,7 @@ reqwest = { version = "0.11", optional = true, default-features = false, feature
 [dev-dependencies]
 serde_json = "1.0"
 tokio = { version = "1.20.1", features = ["full"] }
-electrsd = { version = "0.27.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_25_0"] }
+electrsd = { version = "0.28.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_25_0"] }
 lazy_static = "1.4.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esplora-client"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2018"
 authors = ["Alekos Filini <alekos.filini@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

`partially fixes` [#1422](https://github.com/bitcoindevkit/bdk/issues/1422)

### Description

It updates the rust-bitcoin to 0.32.0, the `bitcoin`crate dependency and `electrsd` to `0.28.0`.

_NOTE: The overall BDK update to `0.32.0` still requires and depends on some other crates, please refer to [#1422](https://github.com/bitcoindevkit/bdk/issues/1422)._

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

It's open for any comments.
<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

- Update the `bitcoin` crate dependency to `0.32.0`
- Update the `electrsd` crate dependency to `0.28.0`

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR