### PR TITLE
fix(ci): pin tokio to 1.38.1 on MSRV step

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -59,6 +59,7 @@ jobs:
         cargo update -p time --precise "0.3.20"
         cargo update -p home --precise 0.5.5
         cargo update -p url --precise "2.5.0"
+        cargo update -p tokio --precise "1.38.1"
     - name: Build
       run: cargo build --features ${{ matrix.features }} --no-default-features
     - name: Clippy

--- a/README.md
+++ b/README.md
@@ -23,4 +23,5 @@ cargo update -p zstd-sys --precise "2.0.8+zstd.1.5.5"
 cargo update -p time --precise "0.3.20"
 cargo update -p home --precise 0.5.5
 cargo update -p url --precise "2.5.0"
+cargo update -p tokio --precise "1.38.1"
 ```


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

As previously noticed on https://github.com/bitcoindevkit/bdk/pull/1524, tokio raised their MSRV to `1.70.0` in their latest release, in short it was because they moved to `mio 1.0` which requires `1.70.0` MSRV.

Although we don't have `tokio` as a direct dependency on `rust-esplora-client` it comes as a transitive dependency from `reqwest`.

This PR adds the necessary pinning on CI and updates the instruction on `README.md` in order to properly build on MSRV.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

- Adds another MSRV pinning step on CI for the `tokio 1.38.1`.

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

<!--
#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR

-->