### PR TITLE
fix(ci): code coverage `actions/upload-artifact` version

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -49,13 +49,12 @@ jobs:
         run: mkdir coverage; grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore '/*' -o ./coverage/lcov.info
       - name: Generate HTML coverage report
         run: genhtml -o coverage-report.html ./coverage/lcov.info
-
       - name: Coveralls upload
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage-report.html

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -38,12 +38,6 @@ jobs:
       - name: Install grcov
         run: if [[ ! -e ~/.cargo/bin/grcov ]]; then cargo install grcov; fi
       - name: Test
-        # WARNING: this is not testing the following features: test-esplora, test-hardware-signer, async-interface
-        # This is because some of our features are mutually exclusive, and generating various reports and
-        # merging them doesn't seem to be working very well.
-        # For more info, see:
-        # - https://github.com/bitcoindevkit/bdk/issues/696
-        # - https://github.com/bitcoindevkit/bdk/pull/748#issuecomment-1242721040
         run: cargo test -- --test-threads=1
       - name: Run grcov
         run: mkdir coverage; grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore '/*' -o ./coverage/lcov.info

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install lcov tools
         run: sudo apt-get install lcov -y
       - name: Install rustup

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -59,6 +59,7 @@ jobs:
         cargo update -p home --precise 0.5.5
         cargo update -p url --precise "2.5.0"
         cargo update -p tokio --precise "1.38.1"
+        cargo update -p tokio-util --precise "0.7.11"
     - name: Build
       run: cargo build --features ${{ matrix.features }} --no-default-features
     - name: Test

--- a/README.md
+++ b/README.md
@@ -24,4 +24,5 @@ cargo update -p time --precise "0.3.20"
 cargo update -p home --precise 0.5.5
 cargo update -p url --precise "2.5.0"
 cargo update -p tokio --precise "1.38.1"
+cargo update -p tokio-util --precise "0.7.11"
 ```


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

The Code Coverage step seems to start failing due to `actions/checkout@v2` becoming deprecated, and an error now instead of a warning. At least it's what I got from the error message here: https://github.com/bitcoindevkit/rust-esplora-client/actions/runs/10702593999/job/29671147653?pr=93

This PR bumps it's version to `v4`, the latest one. I'm also taking the opportunity to bump the `action/checkout` to `v4` too.

I'm not sure if it became fully/enforced deprecation from yesterday to today, because it ran successfully on the last master merged PR CI steps #:thinking: 

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

Please let me know if I should take the opportunity to bump any other actions, or update the workflow in any way.

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

- Bump `actions/upload-artifact` to `v4`.
- Bump `actions/checkout` to `v4`.

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
