### PR TITLE
ci: pin `indexmap` to 2.5.0

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -60,6 +60,7 @@ jobs:
         cargo update -p url --precise "2.5.0"
         cargo update -p tokio --precise "1.38.1"
         cargo update -p tokio-util --precise "0.7.11"
+        cargo update -p indexmap --precise "2.5.0"
     - name: Build
       run: cargo build --features ${{ matrix.features }} --no-default-features
     - name: Test

--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ cargo update -p home --precise 0.5.5
 cargo update -p url --precise "2.5.0"
 cargo update -p tokio --precise "1.38.1"
 cargo update -p tokio-util --precise "0.7.11"
+cargo update -p indexmap --precise "2.5.0"
 ```


### PR DESCRIPTION
Pin `indexmap` to 2.5.0 to build with MSRV