### PR TITLE
Disallow empty blocks response

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -442,7 +442,11 @@ impl<S: Sleeper> AsyncClient<S> {
             Some(height) => format!("/blocks/{height}"),
             None => "/blocks".to_string(),
         };
-        self.get_response_json(&path).await
+        let blocks: Vec<BlockSummary> = self.get_response_json(&path).await?;
+        if blocks.is_empty() {
+            return Err(Error::InvalidResponse);
+        }
+        Ok(blocks)
     }
 
     /// Get the underlying base URL.

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -370,7 +370,11 @@ impl BlockingClient {
             Some(height) => format!("/blocks/{}", height),
             None => "/blocks".to_string(),
         };
-        self.get_response_json(&path)
+        let blocks: Vec<BlockSummary> = self.get_response_json(&path)?;
+        if blocks.is_empty() {
+            return Err(Error::InvalidResponse);
+        }
+        Ok(blocks)
     }
 
     /// Sends a GET request to the given `url`, retrying failed attempts

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,8 @@ pub enum Error {
     InvalidHttpHeaderName(String),
     /// Invalid HTTP Header value specified
     InvalidHttpHeaderValue(String),
+    /// The server sent an invalid response
+    InvalidResponse,
 }
 
 impl fmt::Display for Error {


### PR DESCRIPTION
This is my first attempt at resolving the empty blocks response at the client level. I didn't find that any of the current error variants accurately described the problem, but could use some outside opinions

@oleonardolima @notmandatory 