### PR TITLE
fix(ci): pin `native-tls` to `0.2.13` and `flate2` to `1.0.35`

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -63,6 +63,7 @@ jobs:
         cargo update -p indexmap --precise "2.5.0"
         cargo update -p security-framework-sys --precise "2.11.1"
         cargo update -p native-tls --precise "0.2.13"
+        cargo update -p flate2 --precise "1.0.35"
     - name: Build
       run: cargo build --features ${{ matrix.features }} --no-default-features
     - name: Test

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -62,6 +62,7 @@ jobs:
         cargo update -p tokio-util --precise "0.7.11"
         cargo update -p indexmap --precise "2.5.0"
         cargo update -p security-framework-sys --precise "2.11.1"
+        cargo update -p native-tls --precise "0.2.13"
     - name: Build
       run: cargo build --features ${{ matrix.features }} --no-default-features
     - name: Test

--- a/README.md
+++ b/README.md
@@ -27,4 +27,5 @@ cargo update -p tokio --precise "1.38.1"
 cargo update -p tokio-util --precise "0.7.11"
 cargo update -p indexmap --precise "2.5.0"
 cargo update -p security-framework-sys --precise "2.11.1"
+cargo update -p native-tls --precise "0.2.13"
 ```

--- a/README.md
+++ b/README.md
@@ -28,4 +28,5 @@ cargo update -p tokio-util --precise "0.7.11"
 cargo update -p indexmap --precise "2.5.0"
 cargo update -p security-framework-sys --precise "2.11.1"
 cargo update -p native-tls --precise "0.2.13"
+cargo update -p flate2 --precise "1.0.35"
 ```


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

In the latest `native-tls` release [`0.2.14`](https://github.com/sfackler/rust-native-tls/releases/tag/v0.2.14) it's bumped their MSRV version to `1.80.0`.

It's not a direct dependency, however, it comes as a transitive dependency from `reqwest`.

Alongside that, the `flate2` dependency also bumped their MSRV to `1.67.0` which also requires pinning its version to `1.0.35`.

This PR pins on CI both the `native-tls` to `0.2.13`, and `flate2` to `1.0.35`, and updates the instruction on `README.md` in order to properly build on MSRV.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

- Adds `native-tls 0.2.13` to MSRV pinning step on CI.
- Adds `flate2 1.0.35` to MSRV pinning step on CI.

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

<!--
#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR

-->