### PR TITLE
chore(deps): update `reqwest` to `0.12`

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -54,16 +54,21 @@ jobs:
     - name: Pin dependencies for MSRV
       if: matrix.rust.version == '1.63.0'
       run: |
+        cargo update -p reqwest --precise "0.12.4"
+        cargo update -p minreq --precise "2.13.2"
         cargo update -p zstd-sys --precise "2.0.8+zstd.1.5.5"
         cargo update -p time --precise "0.3.20"
-        cargo update -p home --precise 0.5.5
+        cargo update -p home --precise "0.5.5"
         cargo update -p url --precise "2.5.0"
         cargo update -p tokio --precise "1.38.1"
-        cargo update -p tokio-util --precise "0.7.11"
-        cargo update -p indexmap --precise "2.5.0"
         cargo update -p security-framework-sys --precise "2.11.1"
         cargo update -p native-tls --precise "0.2.13"
+        cargo update -p ring --precise "0.17.12"
         cargo update -p flate2 --precise "1.0.35"
+        cargo update -p once_cell --precise "1.20.3"
+
+        cargo update -p base64ct --precise "1.6.0" # dev-dependency
+        cargo update -p bzip2-sys --precise "0.1.12+1.0.8" # dev-dependency
     - name: Build
       run: cargo build --features ${{ matrix.features }} --no-default-features
     - name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bitcoin = { version = "0.32", features = ["serde", "std"], default-features = fa
 hex = { version = "0.2", package = "hex-conservative" }
 log = "^0.4"
 minreq = { version = "2.11.0", features = ["json-using-serde"], optional = true }
-reqwest = { version = "0.11",  features = ["json"], default-features = false, optional = true }
+reqwest = { version = "0.12",  features = ["json"], default-features = false, optional = true }
 
 # default async runtime
 tokio = { version = "1", features = ["time"], optional = true }

--- a/README.md
+++ b/README.md
@@ -19,14 +19,16 @@ This library should compile with any combination of features with Rust 1.63.0.
 To build with the MSRV you will need to pin dependencies as follows:
 
 ```shell
+cargo update -p reqwest --precise "0.12.4"
+cargo update -p minreq --precise "2.13.2"
 cargo update -p zstd-sys --precise "2.0.8+zstd.1.5.5"
 cargo update -p time --precise "0.3.20"
-cargo update -p home --precise 0.5.5
+cargo update -p home --precise "0.5.5"
 cargo update -p url --precise "2.5.0"
 cargo update -p tokio --precise "1.38.1"
-cargo update -p tokio-util --precise "0.7.11"
-cargo update -p indexmap --precise "2.5.0"
 cargo update -p security-framework-sys --precise "2.11.1"
 cargo update -p native-tls --precise "0.2.13"
+cargo update -p ring --precise "0.17.12"
 cargo update -p flate2 --precise "1.0.35"
+cargo update -p once_cell --precise "1.20.3"
 ```


### PR DESCRIPTION
Updating to LDK 0.1, I noticed `esplora-client` is the last dep we have using `reqwest-v0.11`, which forces us to hold on to a ton of duplicate, old deps in our tree (http 0.2, hyper 0.14, rustls 0.21, ...). Updating `reqwest` to `0.12` removes all these for us.

I've also updated the 1.63.0 MSRV instructions to pin `reqwest-v0.12.9`, the last version with that MSRV. Later `reqwest` versions bump the MSRV to 1.64.0.