### PR TITLE
chore(release): bump version to `0.12.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esplora-client"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Alekos Filini <alekos.filini@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
fixes #125 