### PR TITLE
doc: fix `cargo doc` builds when non-default features selected

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,10 @@
 //! * `async-https-rustls-manual-roots` enables [`reqwest`], the async client with support for
 //!   proxying and TLS (SSL) using the `rustls` TLS backend without using its the default root
 //!   certificates.
-
+//!
+//! [`dont remove this line or cargo doc will break`]: https://example.com
+#![cfg_attr(not(feature = "minreq"), doc = "[`minreq`]: https://docs.rs/minreq")]
+#![cfg_attr(not(feature = "reqwest"), doc = "[`reqwest`]: https://docs.rs/reqwest")]
 #![allow(clippy::result_large_err)]
 
 use std::collections::HashMap;
@@ -87,7 +90,7 @@ pub use blocking::BlockingClient;
 pub use r#async::AsyncClient;
 
 /// Response status codes for which the request may be retried.
-const RETRYABLE_ERROR_CODES: [u16; 3] = [
+pub const RETRYABLE_ERROR_CODES: [u16; 3] = [
     429, // TOO_MANY_REQUESTS
     500, // INTERNAL_SERVER_ERROR
     503, // SERVICE_UNAVAILABLE


### PR DESCRIPTION
While upgrading to `v0.12.0` our `cargo doc` builds broke:

```bash
$ cargo doc --no-default-features --features=async,tokio

# ...

error: unresolved link to `minreq`
  --> /Users/phlip9/dev/esplora-client/src/lib.rs:54:42
   |
54 | //! * `blocking-https-bundled` enables [`minreq`], the blocking client with proxy and TLS (SSL)
   |                                          ^^^^^^ no item named `minreq` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

error: public documentation for `max_retries` links to private item `RETRYABLE_ERROR_CODES`
   --> /Users/phlip9/dev/esplora-client/src/lib.rs:171:21
    |
171 |     /// is one of [`RETRYABLE_ERROR_CODES`].
    |                     ^^^^^^^^^^^^^^^^^^^^^ this item is private

# ... etc
```

To keep the nice doc links to `minreq` and `reqwest`, I just pointed them to <https://docs.rs/minreq> and <https://docs.rs/reqwest> respectively. It won't resolve to the exact version, but it's better than nothing IMO.