### PR TITLE
ci,msrv: pin `tracing-core` to 0.1.33

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -66,6 +66,10 @@ jobs:
         cargo update -p ring --precise "0.17.12"
         cargo update -p flate2 --precise "1.0.35"
         cargo update -p once_cell --precise "1.20.3"
+        cargo update -p tracing-core --precise "0.1.33"
+        cargo update -p parking_lot --precise "0.12.3"
+        cargo update -p parking_lot_core --precise "0.9.10"
+        cargo update -p lock_api --precise "0.4.12"
 
         cargo update -p base64ct --precise "1.6.0" # dev-dependency
         cargo update -p bzip2-sys --precise "0.1.12+1.0.8" # dev-dependency

--- a/README.md
+++ b/README.md
@@ -31,4 +31,8 @@ cargo update -p native-tls --precise "0.2.13"
 cargo update -p ring --precise "0.17.12"
 cargo update -p flate2 --precise "1.0.35"
 cargo update -p once_cell --precise "1.20.3"
+cargo update -p tracing-core --precise "0.1.33"
+cargo update -p parking_lot --precise "0.12.3"
+cargo update -p parking_lot_core --precise "0.9.10"
+cargo update -p lock_api --precise "0.4.12"
 ```

--- a/src/async.rs
+++ b/src/async.rs
@@ -419,8 +419,8 @@ impl<S: Sleeper> AsyncClient<S> {
     ) -> Result<Vec<Tx>, Error> {
         let script_hash = sha256::Hash::hash(script.as_bytes());
         let path = match last_seen {
-            Some(last_seen) => format!("/scripthash/{:x}/txs/chain/{}", script_hash, last_seen),
-            None => format!("/scripthash/{:x}/txs", script_hash),
+            Some(last_seen) => format!("/scripthash/{script_hash:x}/txs/chain/{last_seen}"),
+            None => format!("/scripthash/{script_hash:x}/txs"),
         };
 
         self.get_response_json(&path).await

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -197,7 +197,7 @@ impl BlockingClient {
 
     /// Get a [`Transaction`] option given its [`Txid`]
     pub fn get_tx(&self, txid: &Txid) -> Result<Option<Transaction>, Error> {
-        self.get_opt_response(&format!("/tx/{}/raw", txid))
+        self.get_opt_response(&format!("/tx/{txid}/raw"))
     }
 
     /// Get a [`Transaction`] given its [`Txid`].
@@ -216,44 +216,44 @@ impl BlockingClient {
         block_hash: &BlockHash,
         index: usize,
     ) -> Result<Option<Txid>, Error> {
-        self.get_opt_response_txid(&format!("/block/{}/txid/{}", block_hash, index))
+        self.get_opt_response_txid(&format!("/block/{block_hash}/txid/{index}"))
     }
 
     /// Get the status of a [`Transaction`] given its [`Txid`].
     pub fn get_tx_status(&self, txid: &Txid) -> Result<TxStatus, Error> {
-        self.get_response_json(&format!("/tx/{}/status", txid))
+        self.get_response_json(&format!("/tx/{txid}/status"))
     }
 
     /// Get transaction info given it's [`Txid`].
     pub fn get_tx_info(&self, txid: &Txid) -> Result<Option<Tx>, Error> {
-        self.get_opt_response_json(&format!("/tx/{}", txid))
+        self.get_opt_response_json(&format!("/tx/{txid}"))
     }
 
     /// Get a [`BlockHeader`] given a particular block hash.
     pub fn get_header_by_hash(&self, block_hash: &BlockHash) -> Result<BlockHeader, Error> {
-        self.get_response_hex(&format!("/block/{}/header", block_hash))
+        self.get_response_hex(&format!("/block/{block_hash}/header"))
     }
 
     /// Get the [`BlockStatus`] given a particular [`BlockHash`].
     pub fn get_block_status(&self, block_hash: &BlockHash) -> Result<BlockStatus, Error> {
-        self.get_response_json(&format!("/block/{}/status", block_hash))
+        self.get_response_json(&format!("/block/{block_hash}/status"))
     }
 
     /// Get a [`Block`] given a particular [`BlockHash`].
     pub fn get_block_by_hash(&self, block_hash: &BlockHash) -> Result<Option<Block>, Error> {
-        self.get_opt_response(&format!("/block/{}/raw", block_hash))
+        self.get_opt_response(&format!("/block/{block_hash}/raw"))
     }
 
     /// Get a merkle inclusion proof for a [`Transaction`] with the given
     /// [`Txid`].
     pub fn get_merkle_proof(&self, txid: &Txid) -> Result<Option<MerkleProof>, Error> {
-        self.get_opt_response_json(&format!("/tx/{}/merkle-proof", txid))
+        self.get_opt_response_json(&format!("/tx/{txid}/merkle-proof"))
     }
 
     /// Get a [`MerkleBlock`] inclusion proof for a [`Transaction`] with the
     /// given [`Txid`].
     pub fn get_merkle_block(&self, txid: &Txid) -> Result<Option<MerkleBlock>, Error> {
-        self.get_opt_response_hex(&format!("/tx/{}/merkleblock-proof", txid))
+        self.get_opt_response_hex(&format!("/tx/{txid}/merkleblock-proof"))
     }
 
     /// Get the spending status of an output given a [`Txid`] and the output
@@ -263,7 +263,7 @@ impl BlockingClient {
         txid: &Txid,
         index: u64,
     ) -> Result<Option<OutputStatus>, Error> {
-        self.get_opt_response_json(&format!("/tx/{}/outspend/{}", txid, index))
+        self.get_opt_response_json(&format!("/tx/{txid}/outspend/{index}"))
     }
 
     /// Broadcast a [`Transaction`] to Esplora
@@ -309,7 +309,7 @@ impl BlockingClient {
 
     /// Get the [`BlockHash`] of a specific block height
     pub fn get_block_hash(&self, block_height: u32) -> Result<BlockHash, Error> {
-        self.get_response_str(&format!("/block-height/{}", block_height))
+        self.get_response_str(&format!("/block-height/{block_height}"))
             .map(|s| BlockHash::from_str(s.as_str()).map_err(Error::HexToArray))?
     }
 
@@ -354,8 +354,8 @@ impl BlockingClient {
     ) -> Result<Vec<Tx>, Error> {
         let script_hash = sha256::Hash::hash(script.as_bytes());
         let path = match last_seen {
-            Some(last_seen) => format!("/scripthash/{:x}/txs/chain/{}", script_hash, last_seen),
-            None => format!("/scripthash/{:x}/txs", script_hash),
+            Some(last_seen) => format!("/scripthash/{script_hash:x}/txs/chain/{last_seen}"),
+            None => format!("/scripthash/{script_hash:x}/txs"),
         };
         self.get_response_json(&path)
     }
@@ -367,7 +367,7 @@ impl BlockingClient {
     /// esplora returns `10` while [mempool.space](https://mempool.space/docs/api) returns `15`.
     pub fn get_blocks(&self, height: Option<u32>) -> Result<Vec<BlockSummary>, Error> {
         let path = match height {
-            Some(height) => format!("/blocks/{}", height),
+            Some(height) => format!("/blocks/{height}"),
             None => "/blocks".to_string(),
         };
         let blocks: Vec<BlockSummary> = self.get_response_json(&path)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -323,14 +323,14 @@ mod test {
 
         let esplora_url = ELECTRSD.esplora_url.as_ref().unwrap();
 
-        let mut builder = Builder::new(&format!("http://{}", esplora_url));
+        let mut builder = Builder::new(&format!("http://{esplora_url}"));
         if !headers.is_empty() {
             builder.headers = headers;
         }
 
         let blocking_client = builder.build_blocking();
 
-        let builder_async = Builder::new(&format!("http://{}", esplora_url));
+        let builder_async = Builder::new(&format!("http://{esplora_url}"));
 
         #[cfg(feature = "tokio")]
         let async_client = builder_async.build_async().unwrap();


### PR DESCRIPTION
PR updates the pinned dependencies to build on MSRV. Opening this to test out the changes in CI.

- pin `tracing-core` to 0.1.33
- pin `parking_lot` to 0.12.3
- pin `parking_lot_core` to 0.9.10
- pin `lock_api` to 0.4.12