### PR TITLE
chore(deps): bump `webpki-roots` to 1.0.4, pin `quote` to 1.0.41

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -73,6 +73,7 @@ jobs:
         cargo update -p openssl --precise "0.10.73"
         cargo update -p openssl-sys --precise "0.9.109"
         cargo update -p syn --precise "2.0.106"
+        cargo update -p quote --precise "1.0.41"
 
         cargo update -p bzip2-sys --precise "0.1.12+1.0.8" # dev-dependency
     - name: Build

--- a/README.md
+++ b/README.md
@@ -38,4 +38,5 @@ cargo update -p webpki-roots@1.0.4 --precise "1.0.1"
 cargo update -p openssl --precise "0.10.73"
 cargo update -p openssl-sys --precise "0.9.109"
 cargo update -p syn --precise "2.0.106"
+cargo update -p quote --precise "1.0.41"
 ```


### PR DESCRIPTION
# Changelog
- Bump `webpki-roots` to 1.0.4
- Pin `quote` to 1.0.41

This PR bumps and pins a couple dependencies to fix CI breakage.