### PR TITLE
feat(ci): always run `CI` workflow

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -1,10 +1,6 @@
-name: CI
+on: [push, pull_request]
 
-on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+name: CI
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This PR modifies the `CI` workflow to run on all branches and pull requests, on par with what is currently done on `bdk` and `bdk_wallet`. 

This makes it easier to run CI on forks without having to change the workflow locally.