### PR TITLE
feat(client)!: update broadcast API 

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -371,13 +371,12 @@ impl<S: Sleeper> AsyncClient<S> {
             .await
     }
 
-    /// Broadcast a [`Transaction`] to Esplora.
-    pub async fn broadcast(&self, transaction: &Transaction) -> Result<(), Error> {
+    /// Broadcast a [`Transaction`] to Esplora
+    pub async fn broadcast(&self, transaction: &Transaction) -> Result<Txid, Error> {
         let body = serialize::<Transaction>(transaction).to_lower_hex_string();
-        match self.post_request_bytes("/tx", body, None).await {
-            Ok(_resp) => Ok(()),
-            Err(e) => Err(e),
-        }
+        let response = self.post_request_bytes("/tx", body, None).await?;
+        let txid = Txid::from_str(&response.text().await?).map_err(Error::HexToArray)?;
+        Ok(txid)
     }
 
     /// Broadcast a package of [`Transaction`]s to Esplora.

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -289,8 +289,8 @@ impl BlockingClient {
         self.get_opt_response_json(&format!("/tx/{txid}/outspend/{index}"))
     }
 
-    /// Broadcast a [`Transaction`] to Esplora.
-    pub fn broadcast(&self, transaction: &Transaction) -> Result<(), Error> {
+    /// Broadcast a [`Transaction`] to Esplora
+    pub fn broadcast(&self, transaction: &Transaction) -> Result<Txid, Error> {
         let request = self.post_request(
             "/tx",
             serialize(transaction)
@@ -305,7 +305,10 @@ impl BlockingClient {
                 let message = resp.as_str().unwrap_or_default().to_string();
                 Err(Error::HttpResponse { status, message })
             }
-            Ok(_resp) => Ok(()),
+            Ok(resp) => {
+                let txid = Txid::from_str(resp.as_str()?).map_err(Error::HexToArray)?;
+                Ok(txid)
+            }
             Err(e) => Err(Error::Minreq(e)),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1408,4 +1408,41 @@ mod test {
         assert_eq!(mempool_address_txs_blocking, mempool_address_txs_async);
         assert_eq!(mempool_address_txs_blocking.len(), 5);
     }
+
+    #[cfg(all(feature = "blocking", feature = "async"))]
+    #[tokio::test]
+    async fn test_broadcast() {
+        let (blocking_client, async_client) = setup_clients().await;
+
+        let address = BITCOIND
+            .client
+            .new_address_with_type(AddressType::Legacy)
+            .unwrap();
+
+        let txid = BITCOIND
+            .client
+            .send_to_address(&address, Amount::from_sat(1000))
+            .unwrap()
+            .txid()
+            .unwrap();
+
+        let tx = BITCOIND
+            .client
+            .get_transaction(txid)
+            .expect("tx should exist for given `txid`")
+            .into_model()
+            .expect("should convert successfully")
+            .tx;
+
+        let blocking_res = blocking_client
+            .broadcast(&tx)
+            .expect("should succesfully broadcast tx");
+        let async_res = async_client
+            .broadcast(&tx)
+            .await
+            .expect("should successfully broadcast tx");
+
+        assert_eq!(blocking_res, txid);
+        assert_eq!(async_res, txid);
+    }
 }


### PR DESCRIPTION
### Description
It's a remaining follow-up from #114, it does the remaining breaking change to broadcast API.

### Changelog Notice

```
### Changed

BREAKING CHANGE: changes the `broadcast` method to return the `txid` for
broadcasted transaction, on both `AsyncClient` and `BlockingClient`.
```