### PR TITLE
fix(ci): bump pinned `webpki-roots` to 1.0.5

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -75,6 +75,7 @@ jobs:
         cargo update -p itoa --precise "1.0.15"
         cargo update -p serde_json --precise "1.0.145"
         cargo update -p ryu --precise "1.0.20"
+        cargo update -p proc-macro2 --precise "1.0.103"
 
         cargo update -p bzip2-sys --precise "0.1.12+1.0.8" # dev-dependency
     - name: Build

--- a/README.md
+++ b/README.md
@@ -44,4 +44,5 @@ cargo update -p log --precise "0.4.28"
 cargo update -p itoa --precise "1.0.15"
 cargo update -p serde_json --precise "1.0.145"
 cargo update -p ryu --precise "1.0.20"
+cargo update -p proc-macro2 --precise "1.0.103"
 ```


### PR DESCRIPTION
I was about to merge #114, but there's been a new release (i.e [v1.0.5](https://crates.io/crates/webpki-roots/versions)) for `webpki-roots` which breaks our MSRV CI.

This PR updates its pinned version to fix our MSRV CI jobs, so we can move forward with #114.