### PR TITLE
fix(test): remove `lazy_static` and call `Drop` on test exit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ tokio = { version = "1", features = ["time"], optional = true }
 [dev-dependencies]
 tokio = { version = "1.20.1", features = ["full"] }
 electrsd = { version = "0.33.0", features = ["legacy", "esplora_a33e97e1", "corepc-node_28_0"] }
-lazy_static = "1.4.0"
 
 [features]
 default = ["blocking", "async", "async-https", "tokio"]


### PR DESCRIPTION
Closes #149.

This PR fixes the resource leakage issue on the test suite caused due to the `BITCOIND` and `ELECTRSD` statics not being `Drop`ped on exit, and removes the `lazy_static` dev-dependency.

This is done by registering a cleanup routine via `libc`'s `atexit`. Once the process terminates, it takes ownership of `BITCOIND` and `ELECTRSD` and calls `drop()` on them.

# Verifying the fix:

1. Run the tests on `master` and check for any lingering `bitcoind` processes:
```console
luisschwab@deepthought rust-esplora-client % just test
cargo test --all-features -- --test-threads=1
   Compiling esplora-client v0.12.1 (/Users/luisschwab/git/rust-esplora-client)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.39s
     Running unittests src/lib.rs (target/debug/deps/esplora_client-49d1734ac197afec)

running 32 tests
test test::feerate_parsing ... ok
test test::test_get_address_stats ... ok
test test::test_get_address_txs ... ok
test test::test_get_address_utxos ... ok
test test::test_get_block_by_hash ... ok
test test::test_get_block_by_hash_not_existing ... ok
test test::test_get_block_hash ... ok
test test::test_get_block_info ... ok
test test::test_get_block_status ... ok
test test::test_get_block_txids ... ok
test test::test_get_block_txs ... ok
test test::test_get_blocks ... ok
test test::test_get_fee_estimates ... ok
test test::test_get_header_by_hash ... ok
test test::test_get_height ... ok
test test::test_get_merkle_block ... ok
test test::test_get_merkle_proof ... ok
test test::test_get_non_existing_block_status ... ok
test test::test_get_output_status ... ok
test test::test_get_scripthash_stats ... ok
test test::test_get_scripthash_utxos ... ok
test test::test_get_tip_hash ... ok
test test::test_get_tx ... ok
test test::test_get_tx_info ... ok
test test::test_get_tx_no_opt ... ok
test test::test_get_tx_outspends ... ok
test test::test_get_tx_status ... ok
test test::test_get_tx_with_http_header ... ok
test test::test_get_txid_at_block_index ... ok
test test::test_mempool_methods ... ok
test test::test_scripthash_txs ... ok
test test::test_that_errors_are_propagated ... ok

test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 15.50s

   Doc-tests esplora_client

running 2 tests
test src/lib.rs - (line 16) - compile ... ok
test src/lib.rs - (line 28) - compile ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s

luisschwab@deepthought rust-esplora-client % ps aux | grep bitcoind
luisschwab       71177   0.0  0.0 410742832   1696 s000  S+    4:27PM   0:00.00 grep bitcoind
luisschwab       71161   0.0  0.2 411788208  62448 s000  S     4:27PM   0:00.70 /opt/homebrew/bin/bitcoind -datadir=/var/folders/7s/_67ys5jx23z_stpwj2nbz98r0000gn/T/.tmp3Zf4vi -rpcport=63607 -listen=0 -regtest -fallbackfee=0.0001
```

\
2. Kill the lingering `bitcoind` process and check no `bitcoind` process is left:
```console
luisschwab@deepthought rust-esplora-client % killall bitcoind
luisschwab@deepthought rust-esplora-client % ps aux | grep bitcoind
luisschwab       71233   0.0  0.0 410733616   1584 s000  S+    4:29PM   0:00.00 grep bitcoind
```


3. Run the tests on this branch and check for any lingering `bitcoind` process:
```console
luisschwab@deepthought rust-esplora-client % just test
cargo test --all-features -- --test-threads=1
   Compiling esplora-client v0.12.1 (/Users/luisschwab/git/rust-esplora-client)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.68s
     Running unittests src/lib.rs (target/debug/deps/esplora_client-92c898aaf891e50d)

running 32 tests
test test::feerate_parsing ... ok
test test::test_get_address_stats ... ok
test test::test_get_address_txs ... ok
test test::test_get_address_utxos ... ok
test test::test_get_block_by_hash ... ok
test test::test_get_block_by_hash_not_existing ... ok
test test::test_get_block_hash ... ok
test test::test_get_block_info ... ok
test test::test_get_block_status ... ok
test test::test_get_block_txids ... ok
test test::test_get_block_txs ... ok
test test::test_get_blocks ... ok
test test::test_get_fee_estimates ... ok
test test::test_get_header_by_hash ... ok
test test::test_get_height ... ok
test test::test_get_merkle_block ... ok
test test::test_get_merkle_proof ... ok
test test::test_get_non_existing_block_status ... ok
test test::test_get_output_status ... ok
test test::test_get_scripthash_stats ... ok
test test::test_get_scripthash_utxos ... ok
test test::test_get_tip_hash ... ok
test test::test_get_tx ... ok
test test::test_get_tx_info ... ok
test test::test_get_tx_no_opt ... ok
test test::test_get_tx_outspends ... ok
test test::test_get_tx_status ... ok
test test::test_get_tx_with_http_header ... ok
test test::test_get_txid_at_block_index ... ok
test test::test_mempool_methods ... ok
test test::test_scripthash_txs ... ok
test test::test_that_errors_are_propagated ... ok

test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 15.26s

   Doc-tests esplora_client

running 2 tests
test src/lib.rs - (line 16) - compile ... ok
test src/lib.rs - (line 28) - compile ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s

luisschwab@deepthought rust-esplora-client % ps aux | grep bitcoind
luisschwab       71389   0.0  0.0 410733616   1568 s000  S+    4:30PM   0:00.00 grep bitcoind
```
