### PR TITLE
chore: use the `alloc` feature on `serde_json`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", default-features = false }
+serde_json = { version = "1.0", features = ["alloc"], default-features = false }
 bitcoin = { version = "0.32", features = ["serde", "std"], default-features = false }
 hex = { version = "0.2", package = "hex-conservative" }
 log = "^0.4"


### PR DESCRIPTION
This PR imports `serde_json` with the `alloc` feature. 