### PR TITLE
Introduce `ci/pin-msrv.sh` script and `msrv` recipe

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -49,12 +49,7 @@ jobs:
       run: rustup update
     - name: Pin dependencies for MSRV
       if: matrix.rust.version == '1.75.0'
-      run: |
-        cargo update -p minreq --precise "2.13.2"
-        cargo update -p idna_adapter --precise "1.2.0"
-        cargo update -p native-tls --precise "0.2.13"
-        cargo update -p zerofrom --precise "0.1.5"
-        cargo update -p litemap --precise "0.7.4"
+      run: bash ci/pin-msrv.sh
     - name: Build
       run: cargo build --features ${{ matrix.features }} --no-default-features
     - name: Test

--- a/README.md
+++ b/README.md
@@ -16,12 +16,8 @@ Bitcoin Esplora API client library. Supports plaintext, TLS and Onion servers. B
 
 This library should compile with any combination of features with Rust 1.75.0.
 
-To build with the MSRV you will need to pin dependencies as follows:
+To build with the MSRV you will need to pin dependencies:
 
 ```shell
-cargo update -p minreq --precise "2.13.2"
-cargo update -p idna_adapter --precise "1.2.0"
-cargo update -p native-tls --precise "0.2.13"
-cargo update -p zerofrom --precise "0.1.5"
-cargo update -p litemap --precise "0.7.4"
+bash ci/pin-msrv.sh
 ```

--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -x
+set -euo pipefail
+
+# Pin dependencies for MSRV (1.75.0)
+cargo update -p minreq --precise "2.13.2"
+cargo update -p idna_adapter --precise "1.2.0"
+cargo update -p native-tls --precise "0.2.13"
+cargo update -p zerofrom --precise "0.1.5"
+cargo update -p litemap --precise "0.7.4"

--- a/justfile
+++ b/justfile
@@ -1,8 +1,9 @@
 alias b := build
 alias c := check
 alias f := fmt
-alias t := test
+alias m := msrv
 alias p := pre-push
+alias t := test
 
 _default:
    @just --list
@@ -11,7 +12,7 @@ _default:
 build:
    cargo build
 
-# Check code: formatting, compilation, linting, doc comments, and commit signature
+# Check code formatting, compilation, linting, documentation and commit signature
 check:
    cargo +nightly fmt --all -- --check
    cargo check --all-features --all-targets
@@ -25,9 +26,15 @@ check:
 fmt:
    cargo +nightly fmt
 
-# Run all tests on the workspace with all features
-test:
-   cargo test --all-features -- --test-threads=1
+# Build and test using the MSRV toolchain (1.75.0)
+msrv:
+    bash ci/pin-msrv.sh
+    cargo +1.75.0 build --all-features
+    cargo +1.75.0 test --all-features -- --test-threads=1
 
 # Run pre-push suite: format, check, and test
 pre-push: fmt check test
+
+# Run all tests on the workspace with all features
+test:
+   cargo test --all-features -- --test-threads=1


### PR DESCRIPTION
Closes #165.

This PR introduces a `ci/pin-msrv.sh` script, `msrv` recipe, and updates CI to use the script for MSRV pinning.