### PR TITLE
[0.12.x] Fix pinning for MSRV and introduce `ci/pin-msrv.sh` script

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -49,39 +49,7 @@ jobs:
       run: rustup update
     - name: Pin dependencies for MSRV
       if: matrix.rust.version == '1.63.0'
-      run: |
-        cargo update -p reqwest --precise "0.12.4"
-        cargo update -p minreq --precise "2.13.2"
-        cargo update -p home --precise "0.5.5"
-        cargo update -p url --precise "2.5.0"
-        cargo update -p tokio --precise "1.38.1"
-        cargo update -p native-tls --precise "0.2.13"
-        cargo update -p security-framework-sys --precise "2.11.1"
-        cargo update -p ring --precise "0.17.12"
-        cargo update -p flate2 --precise "1.0.35"
-        cargo update -p once_cell --precise "1.20.3"
-        cargo update -p tracing --precise "0.1.41"
-        cargo update -p tracing-core --precise "0.1.33"
-        cargo update -p parking_lot --precise "0.12.3"
-        cargo update -p parking_lot_core --precise "0.9.10"
-        cargo update -p lock_api --precise "0.4.12"
-        cargo update -p socket2@0.6.2 --precise "0.5.10"
-        cargo update -p webpki-roots@1.0.6 --precise "1.0.1"
-        cargo update -p openssl --precise "0.10.73"
-        cargo update -p openssl-sys --precise "0.9.109"
-        cargo update -p syn --precise "2.0.106"
-        cargo update -p quote --precise "1.0.41"
-        cargo update -p log --precise "0.4.28"
-        cargo update -p itoa --precise "1.0.15"
-        cargo update -p serde_json --precise "1.0.145"
-        cargo update -p ryu --precise "1.0.20"
-        cargo update -p proc-macro2 --precise "1.0.103"
-        cargo update -p getrandom@0.4.1 --precise "0.3.4"
-        cargo update -p anyhow --precise "1.0.100"
-        cargo update -p hyper-util --precise "0.1.19"
-        cargo update -p unicode-ident --precise "1.0.22"
-
-        cargo update -p bzip2-sys@0.1.13+1.0.8 --precise "0.1.12+1.0.8" # dev-dependency
+      run: bash ci/pin-msrv.sh
     - name: Build
       run: cargo build --features ${{ matrix.features }} --no-default-features
     - name: Test

--- a/README.md
+++ b/README.md
@@ -16,39 +16,8 @@ Bitcoin Esplora API client library. Supports plaintext, TLS and Onion servers. B
 
 This library should compile with any combination of features with Rust 1.63.0.
 
-To build with the MSRV you will need to pin dependencies as follows:
+To build with the MSRV you will need to pin dependencies:
 
 ```shell
-cargo update -p reqwest --precise "0.12.4"
-cargo update -p minreq --precise "2.13.2"
-cargo update -p home --precise "0.5.5"
-cargo update -p url --precise "2.5.0"
-cargo update -p tokio --precise "1.38.1"
-cargo update -p native-tls --precise "0.2.13"
-cargo update -p security-framework-sys --precise "2.11.1"
-cargo update -p ring --precise "0.17.12"
-cargo update -p flate2 --precise "1.0.35"
-cargo update -p once_cell --precise "1.20.3"
-cargo update -p tracing --precise "0.1.41"
-cargo update -p tracing-core --precise "0.1.33"
-cargo update -p parking_lot --precise "0.12.3"
-cargo update -p parking_lot_core --precise "0.9.10"
-cargo update -p lock_api --precise "0.4.12"
-cargo update -p socket2@0.6.2 --precise "0.5.10"
-cargo update -p webpki-roots@1.0.6 --precise "1.0.1"
-cargo update -p openssl --precise "0.10.73"
-cargo update -p openssl-sys --precise "0.9.109"
-cargo update -p syn --precise "2.0.106"
-cargo update -p quote --precise "1.0.41"
-cargo update -p log --precise "0.4.28"
-cargo update -p itoa --precise "1.0.15"
-cargo update -p serde_json --precise "1.0.145"
-cargo update -p ryu --precise "1.0.20"
-cargo update -p proc-macro2 --precise "1.0.103"
-cargo update -p getrandom@0.4.1 --precise "0.3.4"
-cargo update -p anyhow --precise "1.0.100"
-cargo update -p hyper-util --precise "0.1.19"
-cargo update -p unicode-ident --precise "1.0.22"
-
-cargo update -p bzip2-sys@0.1.13+1.0.8 --precise "0.1.12+1.0.8" # dev-dependency
+bash ci/pin-msrv.sh
 ```

--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -42,4 +42,3 @@ cargo update -p hyper-util --precise "0.1.19"
 cargo update -p unicode-ident --precise "1.0.22"
 
 cargo update -p bzip2-sys@0.1.13+1.0.8 --precise "0.1.12+1.0.8" # dev-dependency
-

--- a/justfile
+++ b/justfile
@@ -1,6 +1,7 @@
 alias b := build
 alias c := check
 alias f := fmt
+alias m := msrv
 alias t := test
 alias p := pre-push
 
@@ -24,6 +25,12 @@ check:
 # Format all code
 fmt:
    cargo +nightly fmt
+
+# Build and test using the MSRV toolchain (1.63.0)
+msrv:
+    bash ci/pin-msrv.sh
+    cargo +1.63.0 build --all-features
+    cargo +1.63.0 test --all-features -- --test-threads=1
 
 # Run all tests on the workspace with all features
 test:


### PR DESCRIPTION
Fixes broken pins for the 1.63.0 MSRV, and introduces a `ci/pin-msrv.sh` script and `msrv` recipe.