### PR TITLE
ci(audit): add new nightly `cargo audit` job

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,18 @@
+# `cargo audit` config file
+#
+# All of the options which can be passed via CLI arguments can also be
+# permanently specified in this file.
+#
+# See original example: https://raw.githubusercontent.com/rustsec/rustsec/refs/heads/main/cargo-audit/audit.toml.example
+
+[advisories]
+ignore = [] # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
+
+# Output Configuration
+[output]
+quiet = false # Only print information on error
+show_tree = true # Show inverse dependency trees along with advisories (default: true)
+
+[yanked]
+enabled = true # Warn for yanked crates in Cargo.lock (default: true)
+update_index = true # Auto-update the crates.io index (default: true)

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,34 @@
+name: Audit
+
+# Performs a security audit of Rust dependencies using `cargo-audit` through the `actions-rust-lang/audit` action.
+# Runs nightly on schedule and when Cargo.toml, Cargo.lock, or audit.toml files are modified.
+# Helps identify known security vulnerabilities in the dependency tree.
+
+on:
+  push:
+    paths:
+      # Run if workflow changes
+      - '.github/workflows/audit.yml'
+      # Run on changed dependencies
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      # Run if the configuration file changes
+      - '**/audit.toml'
+  # Rerun periodically to pick up new advisories
+  schedule:
+    - cron: '0 0 * * *' # Nightly
+  # Run manually
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/audit@v1
+        name: Audit Rust Dependencies


### PR DESCRIPTION
### Description

As I was going through the recent audit issues in `bdk` and `bdk_wallet` I noticed this nightly job was missing here.

I've added the new `audit.yml` job in CI and also added the `.cargo/audit.toml` in case we need to ignore any unapplicable advisories in the future.

### Changelog notice

```

### Added

- ci(audit): add new nightly `cargo audit` job
- chore: add new `.cargo/audit.toml`

```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
