### PR TITLE
Rename `scripthash_txs` to `get_scripthash_txs`

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -471,7 +471,7 @@ impl<S: Sleeper> AsyncClient<S> {
     /// sorted with newest first. Returns 25 transactions per page.
     /// More can be requested by specifying the last txid seen by the previous
     /// query.
-    pub async fn scripthash_txs(
+    pub async fn get_scripthash_txs(
         &self,
         script: &Script,
         last_seen: Option<Txid>,

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -433,7 +433,7 @@ impl BlockingClient {
     /// sorted with newest first. Returns 25 transactions per page.
     /// More can be requested by specifying the last txid seen by the previous
     /// query.
-    pub fn scripthash_txs(
+    pub fn get_scripthash_txs(
         &self,
         script: &Script,
         last_seen: Option<Txid>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -954,7 +954,7 @@ mod test {
 
     #[cfg(all(feature = "blocking", feature = "async"))]
     #[tokio::test]
-    async fn test_scripthash_txs() {
+    async fn test_get_scripthash_txs() {
         let env = TestEnv::new();
         let (blocking_client, async_client) = env.setup_clients();
 
@@ -976,13 +976,13 @@ mod test {
             .tx;
         let script = &expected_tx.output[0].script_pubkey;
         let scripthash_txs_txids: Vec<Txid> = blocking_client
-            .scripthash_txs(script, None)
+            .get_scripthash_txs(script, None)
             .unwrap()
             .iter()
             .map(|tx| tx.txid)
             .collect();
         let scripthash_txs_txids_async: Vec<Txid> = async_client
-            .scripthash_txs(script, None)
+            .get_scripthash_txs(script, None)
             .await
             .unwrap()
             .iter()


### PR DESCRIPTION
Closes #142 

## Changelog
```
### Changed
- Rename `scripthash_txs` to ` get_scripthash_txs`
```