### PR TITLE
Use `bitcoin::Weight` for all weight fields

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -117,7 +117,7 @@ pub struct Tx {
     /// The [`Transaction`] size in raw bytes (NOT virtual bytes).
     pub size: usize,
     /// The [`Transaction`]'s weight units.
-    pub weight: u64,
+    pub weight: Weight,
     /// The confirmation status of the [`Transaction`].
     pub status: TxStatus,
     /// The fee amount paid by the [`Transaction`], in satoshis.
@@ -140,7 +140,7 @@ pub struct BlockInfo {
     /// The [`Block`]'s size, in bytes.
     pub size: usize,
     /// The [`Block`]'s weight.
-    pub weight: u64,
+    pub weight: Weight,
     /// The Merkle root of the transactions in the block.
     pub merkle_root: hash_types::TxMerkleNode,
     /// The [`BlockHash`] of the previous [`Block`] (`None` for the genesis block).
@@ -408,11 +408,6 @@ impl Tx {
                 })
             })
             .collect()
-    }
-
-    /// Get the weight of a [`Tx`].
-    pub fn weight(&self) -> Weight {
-        Weight::from_wu(self.weight)
     }
 
     /// Get the fee paid by a [`Tx`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -683,7 +683,7 @@ mod test {
         assert_eq!(tx_info.txid, txid);
         assert_eq!(tx_info.to_tx(), tx_exp);
         assert_eq!(tx_info.size, tx_exp.total_size());
-        assert_eq!(tx_info.weight(), tx_exp.weight());
+        assert_eq!(tx_info.weight, tx_exp.weight());
         assert_eq!(tx_info.fee(), tx_res.fee.unwrap().unsigned_abs());
         assert!(tx_info.status.confirmed);
         assert_eq!(tx_info.status.block_height, Some(tx_block_height));


### PR DESCRIPTION
Closes #191 

## Changlog
```
## Changed
- Use `bitcoin::Weight` for all weight fields
```