### PR TITLE
Use `bitcoin::Amount` for all bitcoin value/amount fields

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -42,7 +42,8 @@ pub struct Vin {
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Vout {
     /// The value of the output, in satoshis.
-    pub value: u64,
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub value: Amount,
     /// The ScriptPubKey that the output is locked to, as a [`ScriptBuf`].
     pub scriptpubkey: ScriptBuf,
 }
@@ -121,7 +122,8 @@ pub struct Tx {
     /// The confirmation status of the [`Transaction`].
     pub status: TxStatus,
     /// The fee amount paid by the [`Transaction`], in satoshis.
-    pub fee: u64,
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub fee: Amount,
 }
 
 /// Information about a bitcoin [`Block`].
@@ -217,11 +219,13 @@ pub struct AddressTxsSummary {
     /// The number of funded [`TxOut`]s.
     pub funded_txo_count: u32,
     /// The sum of the funded [`TxOut`]s, in satoshis.
-    pub funded_txo_sum: u64,
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub funded_txo_sum: Amount,
     /// The number of spent [`TxOut`]s.
     pub spent_txo_count: u32,
     /// The sum of the spent [`TxOut`]s, in satoshis.
-    pub spent_txo_sum: u64,
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub spent_txo_sum: Amount,
     /// The total number of [`Transaction`]s.
     pub tx_count: u32,
 }
@@ -261,7 +265,8 @@ pub struct Utxo {
     pub vout: u32,
     /// The confirmation status of the [`TxOut`].
     pub status: UtxoStatus,
-    /// The value of the [`TxOut`] as an [`Amount`].
+    /// The value of the [`TxOut`], in satoshis.
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
     pub value: Amount,
 }
 
@@ -273,7 +278,8 @@ pub struct MempoolStats {
     /// The total size of mempool [`Transaction`]s, in virtual bytes.
     pub vsize: usize,
     /// The total fee paid by mempool [`Transaction`]s, in satoshis.
-    pub total_fee: u64,
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub total_fee: Amount,
     /// The mempool's fee rate distribution histogram.
     ///
     /// An array of `(feerate, vsize)` tuples, where each entry's `vsize` is the total vsize
@@ -288,11 +294,13 @@ pub struct MempoolRecentTx {
     /// The [`Transaction`]'s ID, as a [`Txid`].
     pub txid: Txid,
     /// The [`Amount`] of fees paid by the transaction, in satoshis.
-    pub fee: u64,
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub fee: Amount,
     /// The [`Transaction`]'s size, in virtual bytes.
     pub vsize: usize,
     /// Combined [`Amount`] of the [`Transaction`], in satoshis.
-    pub value: u64,
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub value: Amount,
 }
 
 /// The result for a broadcasted package of [`Transaction`]s.
@@ -376,7 +384,7 @@ impl Tx {
                 .iter()
                 .cloned()
                 .map(|vout| TxOut {
-                    value: Amount::from_sat(vout.value),
+                    value: vout.value,
                     script_pubkey: vout.scriptpubkey,
                 })
                 .collect(),
@@ -404,7 +412,7 @@ impl Tx {
             .map(|vin| {
                 vin.prevout.map(|po| TxOut {
                     script_pubkey: po.scriptpubkey,
-                    value: Amount::from_sat(po.value),
+                    value: po.value,
                 })
             })
             .collect()
@@ -417,7 +425,7 @@ impl Tx {
 
     /// Get the fee paid by a [`Tx`].
     pub fn fee(&self) -> Amount {
-        Amount::from_sat(self.fee)
+        self.fee
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1256,7 +1256,10 @@ mod test {
         let address_stats_async = async_client.get_address_stats(&address).await.unwrap();
         assert_eq!(address_stats_blocking, address_stats_async);
         assert_eq!(address_stats_async.chain_stats.funded_txo_count, 1);
-        assert_eq!(address_stats_async.chain_stats.funded_txo_sum, 1000);
+        assert_eq!(
+            address_stats_async.chain_stats.funded_txo_sum,
+            Amount::from_sat(1000)
+        );
     }
 
     #[cfg(all(feature = "blocking", feature = "async"))]
@@ -1317,7 +1320,7 @@ mod test {
         );
         assert_eq!(
             scripthash_stats_blocking_legacy.chain_stats.funded_txo_sum,
-            1000
+            Amount::from_sat(1000)
         );
         assert_eq!(scripthash_stats_blocking_legacy.chain_stats.tx_count, 1);
 
@@ -1337,7 +1340,7 @@ mod test {
             scripthash_stats_blocking_p2sh_segwit
                 .chain_stats
                 .funded_txo_sum,
-            1000
+            Amount::from_sat(1000)
         );
         assert_eq!(
             scripthash_stats_blocking_p2sh_segwit.chain_stats.tx_count,
@@ -1358,7 +1361,7 @@ mod test {
         );
         assert_eq!(
             scripthash_stats_blocking_bech32.chain_stats.funded_txo_sum,
-            1000
+            Amount::from_sat(1000)
         );
         assert_eq!(scripthash_stats_blocking_bech32.chain_stats.tx_count, 1);
 
@@ -1376,7 +1379,7 @@ mod test {
         );
         assert_eq!(
             scripthash_stats_blocking_bech32m.chain_stats.funded_txo_sum,
-            1000
+            Amount::from_sat(1000)
         );
         assert_eq!(scripthash_stats_blocking_bech32m.chain_stats.tx_count, 1);
     }


### PR DESCRIPTION
Closes #150 

## Changelog
```
- Use `bitcoin::Amount` for all bitcoin value/amount fields
```