### PR TITLE
Rename `Tx` to `EsploraTx` and add conversions

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -416,11 +416,6 @@ impl EsploraTx {
             })
             .collect()
     }
-
-    /// Get the fee paid by an [`EsploraTx`].
-    pub fn fee(&self) -> Amount {
-        self.fee
-    }
 }
 
 impl From<EsploraTx> for Transaction {

--- a/src/api.rs
+++ b/src/api.rs
@@ -103,7 +103,7 @@ pub struct BlockStatus {
 
 /// A [`Transaction`] in the format returned by Esplora.
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct Tx {
+pub struct EsploraTx {
     /// The [`Txid`] of the [`Transaction`].
     pub txid: Txid,
     /// The version number of the [`Transaction`].
@@ -358,9 +358,8 @@ pub struct MempoolFeesSubmitPackage {
     pub effective_includes: Option<Vec<Wtxid>>,
 }
 
-impl Tx {
-    /// Convert a transaction from the format returned by Esplora into a `rust-bitcoin`
-    /// [`Transaction`].
+impl EsploraTx {
+    /// Convert a transaction from the format returned by Esplora into a [`Transaction`].
     pub fn to_tx(&self) -> Transaction {
         Transaction {
             version: transaction::Version::non_standard(self.version),
@@ -391,7 +390,7 @@ impl Tx {
         }
     }
 
-    /// Get the confirmation time from a [`Tx`].
+    /// Get the confirmation time from an [`EsploraTx`].
     pub fn confirmation_time(&self) -> Option<BlockTime> {
         match self.status {
             TxStatus {
@@ -404,7 +403,7 @@ impl Tx {
         }
     }
 
-    /// Get a list of the [`Tx`]'s previous outputs.
+    /// Get a list of the [`EsploraTx`]'s previous outputs.
     pub fn previous_outputs(&self) -> Vec<Option<TxOut>> {
         self.vin
             .iter()
@@ -418,9 +417,21 @@ impl Tx {
             .collect()
     }
 
-    /// Get the fee paid by a [`Tx`].
+    /// Get the fee paid by an [`EsploraTx`].
     pub fn fee(&self) -> Amount {
         self.fee
+    }
+}
+
+impl From<EsploraTx> for Transaction {
+    fn from(tx: EsploraTx) -> Self {
+        tx.to_tx()
+    }
+}
+
+impl From<&EsploraTx> for Transaction {
+    fn from(tx: &EsploraTx) -> Self {
+        tx.to_tx()
     }
 }
 

--- a/src/async.rs
+++ b/src/async.rs
@@ -19,8 +19,8 @@ use bitreq::{Client, Method, Proxy, Request, RequestExt, Response};
 
 use crate::{
     is_retryable, is_success, AddressStats, BlockInfo, BlockStatus, BlockSummary, Builder, Error,
-    MempoolRecentTx, MempoolStats, MerkleProof, OutputStatus, ScriptHashStats, SubmitPackageResult,
-    Tx, TxStatus, Utxo, BASE_BACKOFF_MILLIS,
+    EsploraTx, MempoolRecentTx, MempoolStats, MerkleProof, OutputStatus, ScriptHashStats,
+    SubmitPackageResult, TxStatus, Utxo, BASE_BACKOFF_MILLIS,
 };
 
 /// An async client for interacting with an Esplora API server.
@@ -324,7 +324,7 @@ impl<S: Sleeper> AsyncClient<S> {
     }
 
     /// Get transaction info given its [`Txid`].
-    pub async fn get_tx_info(&self, txid: &Txid) -> Result<Option<Tx>, Error> {
+    pub async fn get_tx_info(&self, txid: &Txid) -> Result<Option<EsploraTx>, Error> {
         self.get_opt_response_json(&format!("/tx/{txid}")).await
     }
 
@@ -466,7 +466,7 @@ impl<S: Sleeper> AsyncClient<S> {
         &self,
         address: &Address,
         last_seen: Option<Txid>,
-    ) -> Result<Vec<Tx>, Error> {
+    ) -> Result<Vec<EsploraTx>, Error> {
         let path = match last_seen {
             Some(last_seen) => format!("/address/{address}/txs/chain/{last_seen}"),
             None => format!("/address/{address}/txs"),
@@ -476,7 +476,10 @@ impl<S: Sleeper> AsyncClient<S> {
     }
 
     /// Get mempool [`Transaction`]s for the specified [`Address`], sorted with newest first.
-    pub async fn get_mempool_address_txs(&self, address: &Address) -> Result<Vec<Tx>, Error> {
+    pub async fn get_mempool_address_txs(
+        &self,
+        address: &Address,
+    ) -> Result<Vec<EsploraTx>, Error> {
         let path = format!("/address/{address}/txs/mempool");
 
         self.get_response_json(&path).await
@@ -490,7 +493,7 @@ impl<S: Sleeper> AsyncClient<S> {
         &self,
         script: &Script,
         last_seen: Option<Txid>,
-    ) -> Result<Vec<Tx>, Error> {
+    ) -> Result<Vec<EsploraTx>, Error> {
         let script_hash = sha256::Hash::hash(script.as_bytes());
         let path = match last_seen {
             Some(last_seen) => format!("/scripthash/{script_hash:x}/txs/chain/{last_seen}"),
@@ -502,7 +505,10 @@ impl<S: Sleeper> AsyncClient<S> {
 
     /// Get mempool [`Transaction`] history for the
     /// specified [`Script`] hash, sorted with newest first.
-    pub async fn get_mempool_scripthash_txs(&self, script: &Script) -> Result<Vec<Tx>, Error> {
+    pub async fn get_mempool_scripthash_txs(
+        &self,
+        script: &Script,
+    ) -> Result<Vec<EsploraTx>, Error> {
         let script_hash = sha256::Hash::hash(script.as_bytes());
         let path = format!("/scripthash/{script_hash:x}/txs/mempool");
 
@@ -555,7 +561,7 @@ impl<S: Sleeper> AsyncClient<S> {
         &self,
         blockhash: &BlockHash,
         start_index: Option<u32>,
-    ) -> Result<Vec<Tx>, Error> {
+    ) -> Result<Vec<EsploraTx>, Error> {
         let path = match start_index {
             None => format!("/block/{blockhash}/txs"),
             Some(start_index) => format!("/block/{blockhash}/txs/{start_index}"),

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -20,8 +20,8 @@ use bitcoin::{Address, Block, BlockHash, MerkleBlock, Script, Transaction, Txid}
 
 use crate::{
     is_retryable, is_success, AddressStats, BlockInfo, BlockStatus, BlockSummary, Builder, Error,
-    MempoolRecentTx, MempoolStats, MerkleProof, OutputStatus, ScriptHashStats, SubmitPackageResult,
-    Tx, TxStatus, Utxo, BASE_BACKOFF_MILLIS,
+    EsploraTx, MempoolRecentTx, MempoolStats, MerkleProof, OutputStatus, ScriptHashStats,
+    SubmitPackageResult, TxStatus, Utxo, BASE_BACKOFF_MILLIS,
 };
 
 /// A blocking client for interacting with an Esplora API server.
@@ -306,7 +306,7 @@ impl BlockingClient {
     }
 
     /// Get transaction info given its [`Txid`].
-    pub fn get_tx_info(&self, txid: &Txid) -> Result<Option<Tx>, Error> {
+    pub fn get_tx_info(&self, txid: &Txid) -> Result<Option<EsploraTx>, Error> {
         self.get_opt_response_json(&format!("/tx/{txid}"))
     }
 
@@ -462,7 +462,7 @@ impl BlockingClient {
         &self,
         address: &Address,
         last_seen: Option<Txid>,
-    ) -> Result<Vec<Tx>, Error> {
+    ) -> Result<Vec<EsploraTx>, Error> {
         let path = match last_seen {
             Some(last_seen) => format!("/address/{address}/txs/chain/{last_seen}"),
             None => format!("/address/{address}/txs"),
@@ -472,7 +472,7 @@ impl BlockingClient {
     }
 
     /// Get mempool [`Transaction`]s for the specified [`Address`], sorted with newest first.
-    pub fn get_mempool_address_txs(&self, address: &Address) -> Result<Vec<Tx>, Error> {
+    pub fn get_mempool_address_txs(&self, address: &Address) -> Result<Vec<EsploraTx>, Error> {
         let path = format!("/address/{address}/txs/mempool");
 
         self.get_response_json(&path)
@@ -486,7 +486,7 @@ impl BlockingClient {
         &self,
         script: &Script,
         last_seen: Option<Txid>,
-    ) -> Result<Vec<Tx>, Error> {
+    ) -> Result<Vec<EsploraTx>, Error> {
         let script_hash = sha256::Hash::hash(script.as_bytes());
         let path = match last_seen {
             Some(last_seen) => format!("/scripthash/{script_hash:x}/txs/chain/{last_seen}"),
@@ -497,7 +497,7 @@ impl BlockingClient {
 
     /// Get mempool [`Transaction`] history for the
     /// specified [`Script`] hash, sorted with newest first.
-    pub fn get_mempool_scripthash_txs(&self, script: &Script) -> Result<Vec<Tx>, Error> {
+    pub fn get_mempool_scripthash_txs(&self, script: &Script) -> Result<Vec<EsploraTx>, Error> {
         let script_hash = sha256::Hash::hash(script.as_bytes());
         let path = format!("/scripthash/{script_hash:x}/txs/mempool");
 
@@ -527,7 +527,7 @@ impl BlockingClient {
         &self,
         blockhash: &BlockHash,
         start_index: Option<u32>,
-    ) -> Result<Vec<Tx>, Error> {
+    ) -> Result<Vec<EsploraTx>, Error> {
         let path = match start_index {
             None => format!("/block/{blockhash}/txs"),
             Some(start_index) => format!("/block/{blockhash}/txs/{start_index}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -684,7 +684,7 @@ mod test {
         assert_eq!(tx_info.to_tx(), tx_exp);
         assert_eq!(tx_info.size, tx_exp.total_size());
         assert_eq!(tx_info.weight, tx_exp.weight());
-        assert_eq!(tx_info.fee(), tx_res.fee.unwrap().unsigned_abs());
+        assert_eq!(tx_info.fee, tx_res.fee.unwrap().unsigned_abs());
         assert!(tx_info.status.confirmed);
         assert_eq!(tx_info.status.block_height, Some(tx_block_height));
         assert_eq!(tx_info.status.block_hash, tx_res.block_hash);


### PR DESCRIPTION
## Changelog
```
- Rename `Tx` to `EsploraTx`
- Add conversions:
  - `EsploraTx` to `Transaction`
  - `&EsploraTx` to `Transaction`
- Remove `EsploraTx::fee`
```