### PR TITLE
Deprecate `BlockSummary` and `get_blocks`

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -189,6 +189,7 @@ pub struct BlockTime {
 }
 
 /// Summary about a [`Block`].
+#[deprecated(since = "0.13.0", note = "use `BlockInfo` instead")]
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct BlockSummary {
     /// The [`Block`]'s hash.

--- a/src/async.rs
+++ b/src/async.rs
@@ -18,10 +18,13 @@ use bitcoin::{Address, Block, BlockHash, MerkleBlock, Script, Transaction, Txid}
 use bitreq::{Client, Method, Proxy, Request, RequestExt, Response};
 
 use crate::{
-    is_retryable, is_success, AddressStats, BlockInfo, BlockStatus, BlockSummary, Builder, Error,
-    EsploraTx, MempoolRecentTx, MempoolStats, MerkleProof, OutputStatus, ScriptHashStats,
-    SubmitPackageResult, TxStatus, Utxo, BASE_BACKOFF_MILLIS,
+    is_retryable, is_success, AddressStats, BlockInfo, BlockStatus, Builder, Error, EsploraTx,
+    MempoolRecentTx, MempoolStats, MerkleProof, OutputStatus, ScriptHashStats, SubmitPackageResult,
+    TxStatus, Utxo, BASE_BACKOFF_MILLIS,
 };
+
+#[allow(deprecated)]
+use crate::BlockSummary;
 
 /// An async client for interacting with an Esplora API server.
 // FIXME: (@oleonardolima) there's no `Debug` implementation for `bitreq::Client`.
@@ -575,6 +578,8 @@ impl<S: Sleeper> AsyncClient<S> {
     ///
     /// The maximum number of summaries returned depends on the backend itself:
     /// esplora returns `10` while [mempool.space](https://mempool.space/docs/api) returns `15`.
+    #[allow(deprecated)]
+    #[deprecated(since = "0.13.0", note = "use `get_block_infos` instead")]
     pub async fn get_blocks(&self, height: Option<u32>) -> Result<Vec<BlockSummary>, Error> {
         let path = match height {
             Some(height) => format!("/blocks/{height}"),

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -19,10 +19,13 @@ use bitcoin::hex::{DisplayHex, FromHex};
 use bitcoin::{Address, Block, BlockHash, MerkleBlock, Script, Transaction, Txid};
 
 use crate::{
-    is_retryable, is_success, AddressStats, BlockInfo, BlockStatus, BlockSummary, Builder, Error,
-    EsploraTx, MempoolRecentTx, MempoolStats, MerkleProof, OutputStatus, ScriptHashStats,
-    SubmitPackageResult, TxStatus, Utxo, BASE_BACKOFF_MILLIS,
+    is_retryable, is_success, AddressStats, BlockInfo, BlockStatus, Builder, Error, EsploraTx,
+    MempoolRecentTx, MempoolStats, MerkleProof, OutputStatus, ScriptHashStats, SubmitPackageResult,
+    TxStatus, Utxo, BASE_BACKOFF_MILLIS,
 };
+
+#[allow(deprecated)]
+use crate::BlockSummary;
 
 /// A blocking client for interacting with an Esplora API server.
 #[derive(Debug, Clone)]
@@ -541,6 +544,8 @@ impl BlockingClient {
     ///
     /// The maximum number of summaries returned depends on the backend itself:
     /// esplora returns `10` while [mempool.space](https://mempool.space/docs/api) returns `15`.
+    #[allow(deprecated)]
+    #[deprecated(since = "0.13.0", note = "use `get_block_infos` instead")]
     pub fn get_blocks(&self, height: Option<u32>) -> Result<Vec<BlockSummary>, Error> {
         let path = match height {
             Some(height) => format!("/blocks/{height}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1110,6 +1110,7 @@ mod test {
         assert_eq!(txs_blocking.len(), txs_async.len());
     }
 
+    #[allow(deprecated)]
     #[cfg(all(feature = "blocking", feature = "async"))]
     #[tokio::test]
     async fn test_get_blocks() {


### PR DESCRIPTION
## Changelog
```
## Changed
- Deprecate `BlockSummary`
- Deprecate `get_blocks`
```