### PR TITLE
Use `bitcoin::Amount` and `bitcoin::FeeRate`

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -286,7 +286,8 @@ pub struct MempoolStats {
     /// An array of `(feerate, vsize)` tuples, where each entry's `vsize` is the total vsize
     /// of [`Transaction`]s paying more than `feerate` but less than the previous entry's `feerate`
     /// (except for the first entry, which has no upper bound).
-    pub fee_histogram: Vec<(f64, usize)>,
+    #[serde(deserialize_with = "deserialize_fee_histogram")]
+    pub fee_histogram: Vec<(FeeRate, Weight)>,
 }
 
 /// A [`Transaction`] that recently entered the mempool.
@@ -457,4 +458,21 @@ where
         return Err(D::Error::custom("feerate overflow"));
     }
     Ok(Some(FeeRate::from_sat_per_kwu(sat_per_kwu as u64)))
+}
+
+fn deserialize_fee_histogram<'de, D>(d: D) -> Result<Vec<(FeeRate, Weight)>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    use serde::de::Error;
+    let raw = Vec::<(f64, Weight)>::deserialize(d)?;
+    raw.into_iter()
+        .map(|(sat_per_vb, vsize)| {
+            let sat_per_kwu = sat_per_vb * 250.0;
+            if !sat_per_kwu.is_finite() {
+                return Err(D::Error::custom("feerate overflow"));
+            }
+            Ok((FeeRate::from_sat_per_kwu(sat_per_kwu as u64), vsize))
+        })
+        .collect()
 }

--- a/src/async.rs
+++ b/src/async.rs
@@ -13,14 +13,14 @@ use bitcoin::consensus::encode::serialize_hex;
 use bitcoin::consensus::{deserialize, serialize, Decodable};
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::hex::{DisplayHex, FromHex};
-use bitcoin::{Address, Block, BlockHash, MerkleBlock, Script, Transaction, Txid};
+use bitcoin::{Address, Amount, Block, BlockHash, FeeRate, MerkleBlock, Script, Transaction, Txid};
 
 use bitreq::{Client, Method, Proxy, Request, RequestExt, Response};
 
 use crate::{
-    is_retryable, is_success, AddressStats, BlockInfo, BlockStatus, Builder, Error, EsploraTx,
-    MempoolRecentTx, MempoolStats, MerkleProof, OutputStatus, ScriptHashStats, SubmitPackageResult,
-    TxStatus, Utxo, BASE_BACKOFF_MILLIS,
+    is_retryable, is_success, sat_per_vbyte_to_feerate, AddressStats, BlockInfo, BlockStatus,
+    Builder, Error, EsploraTx, MempoolRecentTx, MempoolStats, MerkleProof, OutputStatus,
+    ScriptHashStats, SubmitPackageResult, TxStatus, Utxo, BASE_BACKOFF_MILLIS,
 };
 
 #[allow(deprecated)]
@@ -399,31 +399,36 @@ impl<S: Sleeper> AsyncClient<S> {
     pub async fn submit_package(
         &self,
         transactions: &[Transaction],
-        maxfeerate: Option<f64>,
-        maxburnamount: Option<f64>,
+        maxfeerate: Option<FeeRate>,
+        maxburnamount: Option<Amount>,
     ) -> Result<SubmitPackageResult, Error> {
         let serialized_txs = transactions
             .iter()
             .map(|tx| serialize_hex(&tx))
             .collect::<Vec<_>>();
 
-        let mut queryparams = HashSet::<(&str, String)>::new();
+        let mut params = HashSet::<(&str, String)>::new();
+
+        // Esplora expects `maxfeerate` in sats/vB.
         if let Some(maxfeerate) = maxfeerate {
-            queryparams.insert(("maxfeerate", maxfeerate.to_string()));
+            params.insert(("maxfeerate", maxfeerate.to_sat_per_vb_ceil().to_string()));
         }
+        // Esplora expects `maxburnamount` in BTC.
         if let Some(maxburnamount) = maxburnamount {
-            queryparams.insert(("maxburnamount", maxburnamount.to_string()));
+            params.insert(("maxburnamount", maxburnamount.to_btc().to_string()));
         }
 
         let response = self
             .post_request_bytes(
                 "/txs/package",
                 serde_json::to_string(&serialized_txs).map_err(Error::SerdeJson)?,
-                Some(queryparams),
+                Some(params),
             )
             .await?;
 
-        Ok(response.json::<SubmitPackageResult>()?)
+        let result = response.json::<SubmitPackageResult>()?;
+
+        Ok(result)
     }
 
     /// Get the current height of the blockchain tip
@@ -535,10 +540,15 @@ impl<S: Sleeper> AsyncClient<S> {
         self.get_response_json("/mempool/txids").await
     }
 
-    /// Get a map where the key is the confirmation target (in number of
-    /// blocks) and the value is the estimated feerate (in sat/vB).
-    pub async fn get_fee_estimates(&self) -> Result<HashMap<u16, f64>, Error> {
-        self.get_response_json("/fee-estimates").await
+    /// Get fee estimates for a range of confirmation targets.
+    ///
+    /// Returns a [`HashMap`] where the key is the confirmation target in blocks
+    /// and the value is the estimated [`FeeRate`].
+    pub async fn get_fee_estimates(&self) -> Result<HashMap<u16, FeeRate>, Error> {
+        let estimates_raw: HashMap<u16, f64> = self.get_response_json("/fee-estimates").await?;
+        let estimates = sat_per_vbyte_to_feerate(estimates_raw);
+
+        Ok(estimates)
     }
 
     /// Get a summary about a [`Block`], given its [`BlockHash`].

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -16,12 +16,12 @@ use bitcoin::block::Header as BlockHeader;
 use bitcoin::consensus::{deserialize, serialize, Decodable};
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::hex::{DisplayHex, FromHex};
-use bitcoin::{Address, Block, BlockHash, MerkleBlock, Script, Transaction, Txid};
+use bitcoin::{Address, Amount, Block, BlockHash, FeeRate, MerkleBlock, Script, Transaction, Txid};
 
 use crate::{
-    is_retryable, is_success, AddressStats, BlockInfo, BlockStatus, Builder, Error, EsploraTx,
-    MempoolRecentTx, MempoolStats, MerkleProof, OutputStatus, ScriptHashStats, SubmitPackageResult,
-    TxStatus, Utxo, BASE_BACKOFF_MILLIS,
+    is_retryable, is_success, sat_per_vbyte_to_feerate, AddressStats, BlockInfo, BlockStatus,
+    Builder, Error, EsploraTx, MempoolRecentTx, MempoolStats, MerkleProof, OutputStatus,
+    ScriptHashStats, SubmitPackageResult, TxStatus, Utxo, BASE_BACKOFF_MILLIS,
 };
 
 #[allow(deprecated)]
@@ -376,29 +376,34 @@ impl BlockingClient {
     pub fn submit_package(
         &self,
         transactions: &[Transaction],
-        maxfeerate: Option<f64>,
-        maxburnamount: Option<f64>,
+        maxfeerate: Option<FeeRate>,
+        maxburnamount: Option<Amount>,
     ) -> Result<SubmitPackageResult, Error> {
         let serialized_txs = transactions
             .iter()
             .map(|tx| serialize_hex(&tx))
             .collect::<Vec<_>>();
 
-        let mut queryparams = HashSet::<(&str, String)>::new();
+        let mut params = HashSet::<(&str, String)>::new();
+
+        // Esplora expects `maxfeerate` in sats/vB.
         if let Some(maxfeerate) = maxfeerate {
-            queryparams.insert(("maxfeerate", maxfeerate.to_string()));
+            params.insert(("maxfeerate", maxfeerate.to_sat_per_vb_ceil().to_string()));
         }
+        // Esplora expects `maxburnamount` in BTC.
         if let Some(maxburnamount) = maxburnamount {
-            queryparams.insert(("maxburnamount", maxburnamount.to_string()));
+            params.insert(("maxburnamount", maxburnamount.to_btc().to_string()));
         }
 
         let response = self.post_request(
             "/txs/package",
             serde_json::to_string(&serialized_txs).map_err(Error::SerdeJson)?,
-            Some(queryparams),
+            Some(params),
         )?;
 
-        Ok(response.json::<SubmitPackageResult>()?)
+        let result = response.json::<SubmitPackageResult>()?;
+
+        Ok(result)
     }
 
     /// Get the height of the current blockchain tip.
@@ -436,10 +441,15 @@ impl BlockingClient {
         self.get_response_json("/mempool/txids")
     }
 
-    /// Get a map where the key is the confirmation target (in number of
-    /// blocks) and the value is the estimated feerate (in sat/vB).
-    pub fn get_fee_estimates(&self) -> Result<HashMap<u16, f64>, Error> {
-        self.get_response_json("/fee-estimates")
+    /// Get fee estimates for a range of confirmation targets.
+    ///
+    /// Returns a [`HashMap`] where the key is the confirmation target in blocks
+    /// and the value is the estimated [`FeeRate`].
+    pub fn get_fee_estimates(&self) -> Result<HashMap<u16, FeeRate>, Error> {
+        let estimates_raw: HashMap<u16, f64> = self.get_response_json("/fee-estimates")?;
+        let estimates = sat_per_vbyte_to_feerate(estimates_raw);
+
+        Ok(estimates)
     }
 
     /// Get information about a specific address, includes confirmed balance and transactions in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,17 +143,25 @@ fn is_retryable(response: &Response) -> bool {
     RETRYABLE_ERROR_CODES.contains(&(response.status_code as u16))
 }
 
-/// Get a fee value in sats/vbytes from the estimates
-/// that matches the confirmation target set as parameter.
+/// Returns the [`FeeRate`] for the given confirmation target in blocks.
 ///
-/// Returns `None` if no feerate estimate is found at or below `target`
-/// confirmations.
-pub fn convert_fee_rate(target: usize, estimates: HashMap<u16, f64>) -> Option<f32> {
+/// Selects the highest confirmation target from `estimates` that is at or
+/// below `target_blocks`, and returns its [`FeeRate`]. Returns `None` if no
+/// matching estimate is found.
+pub fn convert_fee_rate(target_blocks: usize, estimates: HashMap<u16, FeeRate>) -> Option<FeeRate> {
     estimates
         .into_iter()
-        .filter(|(k, _)| *k as usize <= target)
+        .filter(|(k, _)| *k as usize <= target_blocks)
         .max_by_key(|(k, _)| *k)
-        .map(|(_, v)| v as f32)
+        .map(|(_, feerate)| feerate)
+}
+
+/// Converts a [`HashMap`] of fee estimates expressed as sat/vB ([`f64`]) into a [`FeeRate`].
+pub(crate) fn sat_per_vbyte_to_feerate(estimates: HashMap<u16, f64>) -> HashMap<u16, FeeRate> {
+    estimates
+        .into_iter()
+        .map(|(k, v)| (k, FeeRate::from_sat_per_kwu((v * 250.0).round() as u64)))
+        .collect()
 }
 
 /// A builder for an [`AsyncClient`] or [`BlockingClient`].
@@ -521,51 +529,59 @@ mod test {
     }
 
     #[test]
-    fn feerate_parsing() {
-        let esplora_fees = serde_json::from_str::<HashMap<u16, f64>>(
+    fn test_feerate_parsing() {
+        let esplora_fees_raw = serde_json::from_str::<HashMap<u16, f64>>(
             r#"{
-  "25": 1.015,
-  "5": 2.3280000000000003,
-  "12": 2.0109999999999997,
-  "15": 1.018,
-  "17": 1.018,
-  "11": 2.0109999999999997,
-  "3": 3.01,
-  "2": 4.9830000000000005,
-  "6": 2.2359999999999998,
-  "21": 1.018,
-  "13": 1.081,
-  "7": 2.2359999999999998,
-  "8": 2.2359999999999998,
-  "16": 1.018,
-  "20": 1.018,
-  "22": 1.017,
-  "23": 1.017,
-  "504": 1,
-  "9": 2.2359999999999998,
-  "14": 1.018,
-  "10": 2.0109999999999997,
-  "24": 1.017,
-  "1008": 1,
-  "1": 4.9830000000000005,
-  "4": 2.3280000000000003,
-  "19": 1.018,
-  "144": 1,
-  "18": 1.018
-}
-"#,
+        "1": 1.952,
+        "2": 1.952,
+        "3": 1.199,
+        "4": 1.013,
+        "5": 1.013,
+        "6": 1.013,
+        "7": 1.013,
+        "8": 1.013,
+        "9": 1.013,
+        "10": 1.013,
+        "11": 1.013,
+        "12": 1.013,
+        "13": 0.748,
+        "14": 0.748,
+        "15": 0.748,
+        "16": 0.748,
+        "17": 0.748,
+        "18": 0.748,
+        "19": 0.748,
+        "20": 0.748,
+        "21": 0.748,
+        "22": 0.748,
+        "23": 0.748,
+        "24": 0.748,
+        "25": 0.748,
+        "144": 0.693,
+        "504": 0.693,
+        "1008": 0.693
+    }"#,
         )
         .unwrap();
+
+        // Convert fees from sat/vB (`f64`) to `FeeRate`.
+        // Note that `get_fee_estimates` already returns `HashMap<u16, FeeRate>`.
+        let esplora_fees = sat_per_vbyte_to_feerate(esplora_fees_raw);
+
         assert!(convert_fee_rate(1, HashMap::new()).is_none());
-        assert_eq!(convert_fee_rate(6, esplora_fees.clone()).unwrap(), 2.236);
         assert_eq!(
-            convert_fee_rate(26, esplora_fees.clone()).unwrap(),
-            1.015,
-            "should inherit from value for 25"
+            convert_fee_rate(6, esplora_fees.clone()),
+            Some(FeeRate::from_sat_per_kwu((1.013_f64 * 250.0).round() as u64)),
+            "should inherit from value for target=6"
+        );
+        assert_eq!(
+            convert_fee_rate(26, esplora_fees.clone()),
+            Some(FeeRate::from_sat_per_kwu((0.748_f64 * 250.0).round() as u64)),
+            "should inherit from value for target=25"
         );
         assert!(
             convert_fee_rate(0, esplora_fees).is_none(),
-            "should not return feerate for 0 target"
+            "should not return feerate for target=0"
         );
     }
 


### PR DESCRIPTION
Closes #192 

## Changelog
```
## Added
- Add `deserialize_fee_histogram`

## Breaking 
- Use `Amount` and `FeeRate` on `MempoolStats.fee_histogram`
- `submit_package` takes in `FeeRate` for `maxfeerate` instead of `f64`
- `submit_package` takes in `Amount` for `maxburnamount` instead of `f64`
- `get_fee_estimates` returns `FeeRate` instead of `f64`

## Changed
- Update `test_feerate_parsing` with an up to date fee histogram
```