### PR TITLE
fix: tolerate non-numeric keys in get_fee_estimates (mempool.space deprecation warning)

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -545,7 +545,18 @@ impl<S: Sleeper> AsyncClient<S> {
     /// Returns a [`HashMap`] where the key is the confirmation target in blocks
     /// and the value is the estimated [`FeeRate`].
     pub async fn get_fee_estimates(&self) -> Result<HashMap<u16, FeeRate>, Error> {
-        let estimates_raw: HashMap<u16, f64> = self.get_response_json("/fee-estimates").await?;
+        // Tolerate non-numeric entries in the response. mempool.space added a
+        // non-numeric `"warning"` key to its (deprecated) `/fee-estimates`
+        // endpoint, which makes a strict `HashMap<u16, f64>` deserialization
+        // fail and breaks every downstream caller (e.g. ldk-node refuses to
+        // start). Keep only entries whose key is a numeric confirmation target
+        // and whose value is a number.
+        let raw: HashMap<String, serde_json::Value> =
+            self.get_response_json("/fee-estimates").await?;
+        let estimates_raw: HashMap<u16, f64> = raw
+            .into_iter()
+            .filter_map(|(target, feerate)| Some((target.parse::<u16>().ok()?, feerate.as_f64()?)))
+            .collect();
         let estimates = sat_per_vbyte_to_feerate(estimates_raw);
 
         Ok(estimates)

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -444,7 +444,14 @@ impl BlockingClient {
     /// Returns a [`HashMap`] where the key is the confirmation target in blocks
     /// and the value is the estimated [`FeeRate`].
     pub fn get_fee_estimates(&self) -> Result<HashMap<u16, FeeRate>, Error> {
-        let estimates_raw: HashMap<u16, f64> = self.get_response_json("/fee-estimates")?;
+        // Tolerate non-numeric entries in the response (see the async client and
+        // mempool.space's deprecated `/fee-estimates` `"warning"` key). Keep only
+        // entries whose key is a numeric confirmation target and value a number.
+        let raw: HashMap<String, serde_json::Value> = self.get_response_json("/fee-estimates")?;
+        let estimates_raw: HashMap<u16, f64> = raw
+            .into_iter()
+            .filter_map(|(target, feerate)| Some((target.parse::<u16>().ok()?, feerate.as_f64()?)))
+            .collect();
         let estimates = sat_per_vbyte_to_feerate(estimates_raw);
 
         Ok(estimates)


### PR DESCRIPTION
mempool.space added a non-numeric `"warning"` key to its (deprecated) `/fee-estimates` response:

```json
{"1":4.8, ... ,"1008":0.1,"warning":"This endpoint is deprecated ... use /api/v1/fees/precise"}
```

`get_fee_estimates` deserializes the body as `HashMap<u16, f64>`, so the `"warning"` key fails to parse and the whole call errors. Any client pointed at a mempool.space Esplora is affected.

The most severe downstream impact is **ldk-node**: it calls `get_fee_estimates` during `Node::start()`, so the failed parse makes the node refuse to start and crash-loop on restart. This is a real production failure mode (see #210).

### Fix

Parse `/fee-estimates` leniently: deserialize into a permissive map and keep only entries whose key is a numeric confirmation target and whose value is a number; ignore anything else (such as the `"warning"` string). Behavior is unchanged for spec-compliant servers (e.g. Blockstream). Applied to both the async and blocking clients.

### Changelog

- Fixed: `get_fee_estimates` tolerates non-numeric entries in the `/fee-estimates` response (e.g. mempool.space deprecation `warning`), which previously broke fee estimation for mempool.space-backed clients and prevented ldk-node from starting.

Refs #210