### PR TITLE
Remove deprecated `BlockSummary` and `get_blocks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+* chore!: remove deprecated `BlockSummary` and `get_block` [#225]
+
+### Fixed
+
 ## [0.13.0] – 2026-06-28
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ blocking-https-rustls = ["blocking", "bitreq/https-rustls"]
 blocking-https-rustls-probe = ["blocking", "bitreq/https-rustls-probe"]
 
 [package.metadata.rbmt.toolchains]
-stable = "1.96.0"
-nightly = "nightly-2026-05-08"
+stable = "1.96.1"
+nightly = "nightly-2026-07-03"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/api.rs
+++ b/src/api.rs
@@ -14,7 +14,6 @@ use std::collections::HashMap;
 
 pub use bitcoin::consensus::{deserialize, serialize};
 use bitcoin::hash_types;
-use bitcoin::hash_types::TxMerkleNode;
 pub use bitcoin::hex::FromHex;
 pub use bitcoin::{
     absolute, block, transaction, Address, Amount, Block, BlockHash, CompactTarget, FeeRate,
@@ -209,24 +208,6 @@ pub struct BlockTime {
     pub timestamp: u64,
     /// The block height of the [`Block`].
     pub height: u32,
-}
-
-/// Summary about a [`Block`].
-#[allow(deprecated)]
-#[deprecated(since = "0.13.0", note = "use `BlockInfo` instead")]
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-pub struct BlockSummary {
-    /// The [`BlockHash`] of the [`Block`].
-    pub id: BlockHash,
-    /// The UNIX timestamp and height of the [`Block`].
-    #[serde(flatten)]
-    pub time: BlockTime,
-    /// The [`BlockHash`] of the previous [`Block`].
-    ///
-    /// `None` for the genesis block.
-    pub previousblockhash: Option<BlockHash>,
-    /// The Merkle root of this [`Block`].
-    pub merkle_root: TxMerkleNode,
 }
 
 /// Statistics about an [`Address`].

--- a/src/async.rs
+++ b/src/async.rs
@@ -51,9 +51,6 @@ use crate::{
     OutputStatus, ScriptHashStats, SubmitPackageResult, TxStatus, Utxo, BASE_BACKOFF_MILLIS,
 };
 
-#[allow(deprecated)]
-use crate::BlockSummary;
-
 // FIXME: (@oleonardolima) there's no `Debug` implementation for `bitreq::Client`.
 /// An async client for interacting with an Esplora API server.
 ///
@@ -685,27 +682,6 @@ impl<S: Sleeper> AsyncClient<S> {
         };
 
         self.get_response_json(&path).await
-    }
-
-    /// Get [`BlockInfo`] summaries for recent [`Block`]s.
-    ///
-    /// If `height` is `Some(h)`, returns blocks starting from height `h`.
-    /// If `height` is `None`, returns blocks starting from the current tip.
-    ///
-    /// The maximum number of summaries returned depends on the backend itself:
-    /// Esplora returns `10` while [mempool.space](https://mempool.space/docs/api) returns `15`.
-    #[allow(deprecated)]
-    #[deprecated(since = "0.13.0", note = "use `get_block_infos` instead")]
-    pub async fn get_blocks(&self, height: Option<u32>) -> Result<Vec<BlockSummary>, Error> {
-        let path = match height {
-            Some(height) => format!("/blocks/{height}"),
-            None => "/blocks".to_string(),
-        };
-        let blocks: Vec<BlockSummary> = self.get_response_json(&path).await?;
-        if blocks.is_empty() {
-            return Err(Error::InvalidResponse);
-        }
-        Ok(blocks)
     }
 
     /// Get [`BlockInfo`] summaries for recent [`Block`]s.

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -48,9 +48,6 @@ use crate::{
     OutputStatus, ScriptHashStats, SubmitPackageResult, TxStatus, Utxo, BASE_BACKOFF_MILLIS,
 };
 
-#[allow(deprecated)]
-use crate::BlockSummary;
-
 /// A synchronous client for interacting with an Esplora API server.
 ///
 /// Use [`Builder`] to construct an instance of this client. The client stores
@@ -637,27 +634,6 @@ impl BlockingClient {
         };
 
         self.get_response_json(&path)
-    }
-
-    /// Get [`BlockInfo`] summaries for recent [`Block`]s.
-    ///
-    /// If `height` is `Some(h)`, returns blocks starting from height `h`.
-    /// If `height` is `None`, returns blocks starting from the current tip.
-    ///
-    /// The maximum number of summaries returned depends on the backend itself:
-    /// Esplora returns `10` while [mempool.space](https://mempool.space/docs/api) returns `15`.
-    #[allow(deprecated)]
-    #[deprecated(since = "0.13.0", note = "use `get_block_infos` instead")]
-    pub fn get_blocks(&self, height: Option<u32>) -> Result<Vec<BlockSummary>, Error> {
-        let path = match height {
-            Some(height) => format!("/blocks/{height}"),
-            None => "/blocks".to_string(),
-        };
-        let blocks: Vec<BlockSummary> = self.get_response_json(&path)?;
-        if blocks.is_empty() {
-            return Err(Error::InvalidResponse);
-        }
-        Ok(blocks)
     }
 
     /// Get [`BlockInfo`] summaries for recent [`Block`]s.

--- a/tests/block.rs
+++ b/tests/block.rs
@@ -201,40 +201,6 @@ async fn test_get_block_txs() {
     assert_eq!(txs_blocking.len(), txs_async.len());
 }
 
-#[allow(deprecated)]
-#[tokio::test]
-async fn test_get_blocks() {
-    let env = TestEnv::new();
-    let (blocking_client, async_client) = env.setup_clients();
-
-    let start_height = env.bitcoind_client().get_block_count().unwrap().0;
-    let blocks1 = blocking_client.get_blocks(None).unwrap();
-    let blocks_async1 = async_client.get_blocks(None).await.unwrap();
-    assert_eq!(blocks1[0].time.height, start_height as u32);
-    assert_eq!(blocks1, blocks_async1);
-    env.mine_and_wait(1);
-
-    let blocks2 = blocking_client.get_blocks(None).unwrap();
-    let blocks_async2 = async_client.get_blocks(None).await.unwrap();
-    assert_eq!(blocks2, blocks_async2);
-    assert_ne!(blocks2, blocks1);
-
-    let blocks3 = blocking_client
-        .get_blocks(Some(start_height as u32))
-        .unwrap();
-    let blocks_async3 = async_client
-        .get_blocks(Some(start_height as u32))
-        .await
-        .unwrap();
-    assert_eq!(blocks3, blocks_async3);
-    assert_eq!(blocks3[0].time.height, start_height as u32);
-    assert_eq!(blocks3, blocks1);
-
-    let blocks_genesis = blocking_client.get_blocks(Some(0)).unwrap();
-    let blocks_genesis_async = async_client.get_blocks(Some(0)).await.unwrap();
-    assert_eq!(blocks_genesis, blocks_genesis_async);
-}
-
 #[tokio::test]
 async fn test_get_block_info() {
     let env = TestEnv::new();


### PR DESCRIPTION
Closes #146

## Changelog
```
- Remove deprecated `BlockSummary` type and `get_block` client method
- Bump stable toolchain to v1.96.1 and nightly to nightly-2026-07-03
```