### PR TITLE
Bump `electrsd` to v0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 
+* chore(deps): bump `electrsd` to v0.41.0 [#237]
 * chore!: remove deprecated `BlockSummary` and `get_block` [#225]
 
 ### Fixed

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoind"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ae2e87ae73ae44f76807ec87d30545e84788dfe2620cd825d902c69168d58a"
+checksum = "23bf8ad1dbb61cfc69dd02f5377a8a7bae5c7a299f8644ffedd0f3ea38e2e925"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.13.0",
@@ -305,9 +305,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "corepc-client"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6120efc48c970c94978f846c3c1562cb5e3afa8b00039f3a03f9f68ce4b5d6"
+checksum = "349238a237f42ae84050dc449406a734a752c418b9dd531ecb4e93e7b97d094e"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095534efdb8f2f43d48b9c3e9f35aefdf29ec6a5f1895064f575a67bc2a8dfe"
+checksum = "86c274042a89391a324ab313b5210680969d02a9fa977733c3354aea4d7a4883"
 dependencies = [
  "bitcoin",
  "serde",
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "electrsd"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205be08632bd3a374d70452b1662c468b35e66bef57a53cbbb7b8c1f58d2f328"
+checksum = "7741fbb9d8e3e65f30e4d9cd60c9a9e09a3aa530330b88dfc13468de1a8ec316"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "electrum-client"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7b07e2578a6df0093b101915c79dca0119d7f7810099ad9eef11341d2ae57"
+checksum = "1970c5d7bd9de6d4041cbfc3e46faa3e85fe7efcea2b0eb06750d3ae1ef577b7"
 dependencies = [
  "bitcoin",
  "log",
@@ -972,9 +972,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.2"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "subtle"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoind"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ae2e87ae73ae44f76807ec87d30545e84788dfe2620cd825d902c69168d58a"
+checksum = "23bf8ad1dbb61cfc69dd02f5377a8a7bae5c7a299f8644ffedd0f3ea38e2e925"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -235,9 +235,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6120efc48c970c94978f846c3c1562cb5e3afa8b00039f3a03f9f68ce4b5d6"
+checksum = "349238a237f42ae84050dc449406a734a752c418b9dd531ecb4e93e7b97d094e"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095534efdb8f2f43d48b9c3e9f35aefdf29ec6a5f1895064f575a67bc2a8dfe"
+checksum = "86c274042a89391a324ab313b5210680969d02a9fa977733c3354aea4d7a4883"
 dependencies = [
  "bitcoin",
  "serde",
@@ -275,9 +275,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "electrsd"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205be08632bd3a374d70452b1662c468b35e66bef57a53cbbb7b8c1f58d2f328"
+checksum = "7741fbb9d8e3e65f30e4d9cd60c9a9e09a3aa530330b88dfc13468de1a8ec316"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "electrum-client"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5059f13888a90486e7268bbce59b175f5f76b1c55e5b9c568ceaa42d2b8507c"
+checksum = "1970c5d7bd9de6d4041cbfc3e46faa3e85fe7efcea2b0eb06750d3ae1ef577b7"
 dependencies = [
  "bitcoin",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { version = "1", features = ["time"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-electrsd = { version = "0.40.0", default-features = false, features = ["legacy", "esplora_a33e97e1", "bitcoind_download", "bitcoind_29_0"] }
+electrsd = { version = "0.41.0", default-features = false, features = ["legacy", "esplora_a33e97e1", "bitcoind_download", "bitcoind_29_0"] }
 # These pins are needed for `Cargo-minimal.lock`:
 tar = { version = "0.4.45" } # blame: electrsd v0.38.0 -> bitcoind -> tar
 log = { version = "0.4.29" } # blame: electrsd v0.38.0 -> bitcoind -> corepc_client
@@ -66,9 +66,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.rbmt.lint]
 allowed_duplicates = [
-    "getrandom",
     "windows-sys",
-    "wit-bindgen",
 ]
 
 [package.metadata.rbmt.test]


### PR DESCRIPTION
~Supersedes #232~

## Changelog
```
* Bump `electrsd` to v0.41.0
```