### PR TITLE
Enable async request pipelining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 
+* feat(client): enable request pipelining for `AsyncClient` [#245]
 * chore!: remove deprecated `BlockSummary` and `get_block` [#225]
 
 ### Fixed

--- a/src/async.rs
+++ b/src/async.rs
@@ -156,7 +156,7 @@ impl<S: Sleeper> AsyncClient<S> {
         let mut delay = BASE_BACKOFF_MILLIS;
         let mut attempts = 0;
 
-        let request = self.build_request(Method::Get, path)?;
+        let request = self.build_request(Method::Get, path)?.with_pipelining();
 
         loop {
             match request.clone().send_async_with_client(&self.client).await? {


### PR DESCRIPTION
Fixes #240.

## Changelog
```
* Enable request pipelining for GETs on the `AsyncClient`.
```
